### PR TITLE
Custom llama-stack container distribution building fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Source code for our custom providers.
 
 Manual procedure, assuming an existing PyPI API token available:
 
-    pip install build twine
-    pip -m build
-    twine upload dist/*
+    ## Generate distribution archives to be uploaded into Python registry
+    pdm run python -m build
+    ## Upload distribution archives into Python registry
+    pdm run python -m twine upload --repository ${PYTHON_REGISTRY} dist/*

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # lightspeed-providers
 Source code for our custom providers.
+
+## Building and publishing
+
+Manual procedure, assuming an existing PyPI API token available:
+
+    pip install build twine
+    pip -m build
+    twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ description = "Lightspeed Stack providers for llama-stack"
 requires-python = ">=3.10"
 dependencies = ["llama-stack>=0.2.6", "httpx"]
 
-[tool.setuptools]
-packages = ["lightspeed_stack_providers"]
+[tool.setuptools.packages]
+find = {}
 
 [dependency-groups]
 dev = [

--- a/resources/external_providers/inline/safety/lightspeed_question_validity.yaml
+++ b/resources/external_providers/inline/safety/lightspeed_question_validity.yaml
@@ -1,6 +1,6 @@
 module: lightspeed_stack_providers.providers.inline.safety.lightspeed_question_validity
 config_class: lightspeed_stack_providers.providers.inline.safety.lightspeed_question_validity.config.QuestionValidityShieldConfig
-pip_packages: []
+pip_packages: ["lightspeed_stack_providers"]
 api_dependencies:
   - inference
 optional_api_dependencies: []

--- a/resources/external_providers/remote/tool_runtime/lightspeed.yaml
+++ b/resources/external_providers/remote/tool_runtime/lightspeed.yaml
@@ -1,7 +1,7 @@
 api: Api.tool_runtime
 adapter:
   adapter_type: lightspeed
-  pip_packages: ["mcp"]
+  pip_packages: ["mcp", "lightspeed_stack_providers"]
   config_class: lightspeed_stack_providers.providers.remote.tool_runtime.lightspeed.config.LightspeedToolConfig
   module: lightspeed_stack_providers.providers.remote.tool_runtime.lightspeed
   provider_data_validator: lightspeed_stack_providers.providers.remote.tool_runtime.lightspeed.LightspeedToolProviderDataValidator


### PR DESCRIPTION
**Description**
Those are some changes I did on my local for
- Building the package 
- Publishing the package into pypi
- Fixed the external providers to depend on the `lightspeed_stack_providers` pypi package.

This way, I am able to build and run a custom llama-stack distro for AAP chatbot, see my test repo: https://github.com/romartin/ansible-chatbot-stack

**Requirements**
This PR assumes the `lightspeed_stack_providers` package is published in pypi. Actually I just manually pushed it into: https://pypi.org/project/lightspeed-stack-providers/
