### PR TITLE
[AAP-46162] create lightspeed-inline-agent

### DIFF
--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/__init__.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/__init__.py
@@ -1,0 +1,20 @@
+from typing import Any
+
+from llama_stack.distribution.datatypes import Api
+
+from .config import LightspeedAgentsImplConfig
+
+
+async def get_provider_impl(config: LightspeedAgentsImplConfig, deps: dict[Api, Any]):
+    from .agents import LightspeedAgentsImpl
+
+    impl = LightspeedAgentsImpl(
+        config,
+        deps[Api.inference],
+        deps[Api.vector_io],
+        deps[Api.safety],
+        deps[Api.tool_runtime],
+        deps[Api.tool_groups],
+    )
+    await impl.initialize()
+    return impl

--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agent_instance.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agent_instance.py
@@ -1,0 +1,191 @@
+import json
+import uuid
+from collections.abc import AsyncGenerator
+
+from llama_stack.apis.agents import AgentConfig, AgentTurnCreateRequest
+from llama_stack.log import get_logger
+from llama_stack.providers.inline.agents.meta_reference.agent_instance import ChatAgent
+from llama_stack.providers.utils.telemetry import tracing
+
+from llama_stack.apis.inference import (
+    Inference,
+    UserMessage,
+    SamplingParams,
+    TopPSamplingStrategy,
+)
+from llama_stack.apis.safety import Safety
+from llama_stack.apis.tools import ToolGroups, ToolRuntime
+from llama_stack.apis.vector_io import VectorIO
+from llama_stack.providers.utils.kvstore import KVStore
+
+logger = get_logger(name=__name__, category="agents")
+
+INSTRUCTIONS = """
+You are an intelligent assistant that helps filter a list of available tools based on a user's prompt.
+The tools will be used at later stage for tool calling with the same User Prompt.
+Each tool is provided with its "tool_name" and a "description".
+Your task is to identify which tools are relevant to the user's prompt by considering both the tool_name and description.
+Return only the 'tool_name' of the relevant tools as a JSON list of strings.
+If no tools are relevant, return an empty JSON list.
+
+Example 1:
+Tools List:
+    [
+        {"tool_name": "create_user", "description": "create a user and return the new user information"},
+        {"tool_name": "delete_user", "description": "delete the supplied user"},
+        {"tool_name": "read_user_data", "description": "read a user data"}
+    ]
+User Prompt: "get user information"
+Relevant Tools (JSON list): 
+    [
+        "read_user_data"
+    ]
+
+Example 2:
+Tools List:
+    [
+        {"tool_name": "jobs_list", "description": "List Jobs"},
+        {"tool_name": "workflow_jobs_list", "description": "List workflow Jobs"},
+        {"tool_name": "read_user_data", "description": "read a user data"}
+    ]
+User Prompt: "get jobs list"
+Relevant Tools (JSON list):
+    [
+        "jobs_list",
+        "workflow_jobs_list"
+    ]
+
+Example 3:
+Tools List:
+    [
+        {"tool_name": "job_templates_list", "description": "List Job Templates"}, 
+        {"tool_name": "workflow_job_templates_list", "description": "List Workflow Job Templates"},
+        {"tool_name": "read_user_data", "description": "read a user data"}
+    ]
+User Prompt: "get job templates list"
+Relevant Tools (JSON list):
+    [
+        "job_templates_list",
+        "workflow_job_templates_list"
+    ]
+"""
+
+
+class LightspeedChatAgent(ChatAgent):
+    def __init__(
+        self,
+        agent_id: str,
+        agent_config: AgentConfig,
+        inference_api: Inference,
+        safety_api: Safety,
+        tool_runtime_api: ToolRuntime,
+        tool_groups_api: ToolGroups,
+        vector_io_api: VectorIO,
+        persistence_store: KVStore,
+        created_at: str,
+        tools_filter_model_id: str | None = None,
+        tools_filter_enabled: bool = False,
+    ):
+        super().__init__(
+            agent_id,
+            agent_config,
+            inference_api,
+            safety_api,
+            tool_runtime_api,
+            tool_groups_api,
+            vector_io_api,
+            persistence_store,
+            created_at,
+        )
+        self.tools_filter_enabled = tools_filter_enabled
+        self.tools_filter_model_id = tools_filter_model_id
+
+    async def create_and_execute_turn(
+        self, request: AgentTurnCreateRequest
+    ) -> AsyncGenerator:
+        # Note: This function is the same as the base class one,
+        # except we call _filter_tools_with_request AFTER _initialize_tools
+        span = tracing.get_current_span()
+        if span:
+            span.set_attribute("session_id", request.session_id)
+            span.set_attribute("agent_id", self.agent_id)
+            span.set_attribute("request", request.model_dump_json())
+            turn_id = str(uuid.uuid4())
+            span.set_attribute("turn_id", turn_id)
+            if self.agent_config.name:
+                span.set_attribute("agent_name", self.agent_config.name)
+
+        await self._initialize_tools(request.toolgroups)
+        # after tools initialization filter them by prompt request
+        if self.tools_filter_enabled:
+            await self._filter_tools_with_request(request)
+
+        async for chunk in self._run_turn(request, turn_id):
+            yield chunk
+
+    async def _filter_tools_with_request(self, request: AgentTurnCreateRequest) -> None:
+        """
+        filter self.tool_defs, self.tool_name_to_args to correspond to user prompt
+        """
+
+        message = "\n".join([message.content for message in request.messages])
+        tools = [
+            dict(tool_name=tool.tool_name, description=tool.description)
+            for tool in self.tool_defs
+        ]
+        tools_filter_model_id = self.tools_filter_model_id or self.agent_config.model
+        response = await self.inference_api.chat_completion(
+            tools_filter_model_id,
+            [
+                UserMessage(content=INSTRUCTIONS),
+                UserMessage(
+                    content="Filter the following tools list, the list is a list of dictionaries "
+                    "that contain the tool name and it's corresponding description \n"
+                    f"Tools List:\n {tools} \n"
+                    f'User Prompt: "{message}" \n'
+                    "return a JSON list of strings that correspond to the Relevant Tools, \n"
+                    "a strict top 10 items list is needed,\n"
+                    "use the tool_name and description for the correct filtering.\n"
+                    "return an empty list when no relevant tools found."
+                ),
+            ],
+            stream=False,
+            sampling_params=SamplingParams(
+                strategy=TopPSamplingStrategy(temperature=0.1), max_tokens="2048"
+            ),
+        )
+        content: str = response.completion_message.content
+        logger.debug("response content: >>>>>> %s ", content)
+        filtered_tools_names = []
+        if "[" in content and "]" in content:
+            list_str = content[content.rfind("[") : content.rfind("]") + 1]
+            try:
+                filtered_tools_names = json.loads(list_str)
+                logger.debug("the filtered list is >>>>>> %s ", filtered_tools_names)
+            except Exception as exp:
+                filtered_tools_names = []
+                logger.error(exp)
+
+        if filtered_tools_names:
+            original_tools_count = len(self.tool_defs)
+            self.tool_defs = list(
+                filter(
+                    lambda tool: tool.tool_name in filtered_tools_names, self.tool_defs
+                )
+            )
+            self.tool_name_to_args = {
+                key: value
+                for key, value in self.tool_name_to_args.items()
+                if key in filtered_tools_names
+            }
+            logger.debug(
+                "filtered tools count (how much tools was removed):  >>>>>>> %d ",
+                original_tools_count - len(self.tool_defs),
+            )
+            logger.debug(
+                "new tool names to args keys:  >>>>>>> %s ",
+                list(self.tool_name_to_args.keys()),
+            )
+        else:
+            self.tool_defs = []
+            self.tool_name_to_args = {}

--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
@@ -1,0 +1,64 @@
+from .agent_instance import LightspeedChatAgent
+from llama_stack.providers.inline.agents.meta_reference.persistence import AgentInfo
+
+from llama_stack.providers.inline.agents.meta_reference.agents import (
+    MetaReferenceAgentsImpl,
+)
+
+from llama_stack.apis.inference import Inference
+from llama_stack.apis.safety import Safety
+from llama_stack.apis.tools import ToolGroups, ToolRuntime
+from llama_stack.apis.vector_io import VectorIO
+
+from .config import LightspeedAgentsImplConfig
+
+
+class LightspeedAgentsImpl(MetaReferenceAgentsImpl):
+    def __init__(
+        self,
+        config: LightspeedAgentsImplConfig,
+        inference_api: Inference,
+        vector_io_api: VectorIO,
+        safety_api: Safety,
+        tool_runtime_api: ToolRuntime,
+        tool_groups_api: ToolGroups,
+    ):
+        super().__init__(
+            config,
+            inference_api,
+            vector_io_api,
+            safety_api,
+            tool_runtime_api,
+            tool_groups_api,
+        )
+        self.config = config
+
+    async def _get_agent_impl(self, agent_id: str) -> LightspeedChatAgent:
+        agent_info_json = await self.persistence_store.get(
+            key=f"agent:{agent_id}",
+        )
+        if not agent_info_json:
+            raise ValueError(f"Could not find agent info for {agent_id}")
+
+        try:
+            agent_info = AgentInfo.model_validate_json(agent_info_json)
+        except Exception as e:
+            raise ValueError(f"Could not validate agent info for {agent_id}") from e
+
+        return LightspeedChatAgent(
+            agent_id=agent_id,
+            agent_config=agent_info,
+            inference_api=self.inference_api,
+            safety_api=self.safety_api,
+            vector_io_api=self.vector_io_api,
+            tool_runtime_api=self.tool_runtime_api,
+            tool_groups_api=self.tool_groups_api,
+            persistence_store=(
+                self.persistence_store
+                if agent_info.enable_session_persistence
+                else self.in_memory_store
+            ),
+            created_at=agent_info.created_at,
+            tools_filter_model_id=self.config.tools_filter.model_id,
+            tools_filter_enabled=self.config.tools_filter.enabled,
+        )

--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/config.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/config.py
@@ -1,0 +1,26 @@
+from typing import Any, Optional
+from llama_stack.providers.inline.agents.meta_reference.config import (
+    MetaReferenceAgentsImplConfig,
+)
+
+from pydantic import BaseModel
+
+
+class ToolsFilter(BaseModel):
+    model_id: Optional[str] = None
+    enabled: Optional[bool] = True
+
+
+class LightspeedAgentsImplConfig(MetaReferenceAgentsImplConfig):
+    """Lightspeed agent configuration"""
+
+    tools_filter: Optional[ToolsFilter] = ToolsFilter()
+
+    @classmethod
+    def sample_run_config(cls, __distro_dir__: str) -> dict[str, Any]:
+        config = super().sample_run_config(__distro_dir__)
+        config["tools_filter"] = ToolsFilter(
+            model_id="${env.INFERENCE_MODEL_FILTER}:}",
+            enabled=True,
+        )
+        return config

--- a/resources/external_providers/inline/agents/lightspeed_inline_agent.yaml
+++ b/resources/external_providers/inline/agents/lightspeed_inline_agent.yaml
@@ -1,0 +1,11 @@
+api: Api.agents
+provider_type: inline::lightspeed_inline_agent
+config_class: lightspeed_stack_providers.providers.inline.agents.lightspeed_inline_agent.config.LightspeedAgentsImplConfig
+module: lightspeed_stack_providers.providers.inline.agents.lightspeed_inline_agent
+adapter:
+  adapter_type: lightspeed_inline_agent
+  pip_packages: []
+  config_class: lightspeed_stack_providers.providers.inline.agents.lightspeed_inline_agent.config.LightspeedAgentsImplConfig
+  module: lightspeed_stack_providers.providers.inline.agents.lightspeed_inline_agent
+api_dependencies: [ inference, safety, vector_io, vector_dbs, tool_runtime, tool_groups ]
+optional_api_dependencies: []


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/AAP-46162

This will allow to filter the used tools before submitted to llm usage. 
The principe used here is to submit the tools to llm to filter the tools before it gets analyzed by the main task that can be stuck when the number of tools is very big, 
in our usage the number is more than 800 tools only to count AAP controller with gateway apis, without filtering the LLM simply crash with error:

```
openai.BadRequestError: Error code: 400 - {'object': 'error', 'message': "This model's maximum context length is 35896 tokens. However, you requested 122901 tokens (120853 in the messages, 2048 in the completion). Please reduce the length of the messages or completion.", 'type': 'BadRequestError', 'param': None, 'code': 400}
```

configuration:
in llama xxx-run.yaml
```
 agents:
  - provider_id: lightspeed_inline_agent
    provider_type: inline::lightspeed_inline_agent
    config:
      persistence_store:
        type: sqlite
        namespace: null
        db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/ollama}/agents_store.db
      responses_store:
        type: sqlite
        db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/ollama}/responses_store.db
      tools_filter:
        enabled: true
        model_id: ${env.INFERENCE_MODEL_FILTER:}
```

if enabled the filtering is activated, if the filter will use an other model than the agent we can set INFERENCE_MODEL_FILTER env with the model_id.

if disabled this will behave like the default llama-stack inline agent
   
   




