### PR TITLE
[AAP-47672] Enhance lightspeed too_runtime to handle multi-headers

### DIFF
--- a/lightspeed_stack_providers/providers/remote/tool_runtime/lightspeed/__init__.py
+++ b/lightspeed_stack_providers/providers/remote/tool_runtime/lightspeed/__init__.py
@@ -1,35 +1,15 @@
 from typing import Any, Optional
-from typing_extensions import Self
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel
 
 from llama_stack.distribution.datatypes import Api
 
-from .auth_type import AuthType
+
 from .config import LightspeedToolConfig
 
 
 class LightspeedToolProviderDataValidator(BaseModel):
-    lightspeed_api_key: str
-    lightspeed_auth_type: AuthType
-    lightspeed_auth_header: Optional[str] = None
-
-    @model_validator(mode="after")
-    def check_llama_stack_model(self) -> Self:
-        if (
-            self.lightspeed_auth_type == AuthType.Bearer
-            and self.lightspeed_auth_header is not None
-        ):
-            raise ValueError(
-                "header is not required when using bearer authentication type"
-            )
-        if (
-            self.lightspeed_auth_type == AuthType.Header
-            and self.lightspeed_auth_header is None
-        ):
-            raise ValueError("header is required when using header authentication type")
-
-        return self
+    lightspeed_tool_groups_headers: Optional[dict[str, dict[str, str]]] = {"*": {}}
 
 
 async def get_adapter_impl(config: LightspeedToolConfig, _deps: dict[Api, Any]):

--- a/lightspeed_stack_providers/providers/remote/tool_runtime/lightspeed/auth_type.py
+++ b/lightspeed_stack_providers/providers/remote/tool_runtime/lightspeed/auth_type.py
@@ -1,6 +1,0 @@
-from enum import Enum
-
-
-class AuthType(Enum):
-    Bearer = "bearer"
-    Header = "header"


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/AAP-47672

Enhance lightspeed too_runtime to handle multi-headers, also it's possible to select which headers are used for all mcp toolgroups and which will be used for specific one, the specific one may override the general one.

we still support the global api_key set in llama-stack xxx-run.yaml file 

example usage:

any tool_group will have passed the CLIENT header, "mcp::aap-controller" will be passed the JWT key, the gateway one the authorization header
```
LlamaStackClient(
    base_url="http://localhost:8321", 
    provider_data={
            "lightspeed_tool_groups_headers": {
                "*": {
                    "CLIENT": "LIGHTSPEED"
                },
                "mcp::aap-controller": {
                    "X-DAB-JW-TOKEN": "<the needed JWT-token>" 
                },
                "mcp::aap-gateway": {
                    "Authorization": f"Bearer {api_key}"
                },
            },
        }
)

```