### PR TITLE
To update llama-stack to 0.2.12 to use healthcheck implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "lightspeed_stack_providers"
 version = "0.1.3"
 description = "Lightspeed Stack providers for llama-stack"
 requires-python = ">=3.10"
-dependencies = ["llama-stack>=0.2.9", "httpx", "pydantic>=2.10.6"]
+dependencies = ["llama-stack>=0.2.12", "httpx", "pydantic>=2.10.6"]
 
 [tool.setuptools.packages]
 find = {}


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-47980. To update llama-stack to 0.2.12 to use healthcheck implementation