### PR TITLE
Release 0.1.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lightspeed_stack_providers"
-version = "0.1.10"
+version = "0.1.11"
 description = "Lightspeed Stack providers for llama-stack"
 requires-python = ">=3.12"
 dependencies = ["llama-stack==0.2.14", "httpx", "pydantic>=2.10.6"]

--- a/uv.lock
+++ b/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "lightspeed-stack-providers"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Release version `0.1.11` to PyPi.

See https://pypi.org/project/lightspeed-stack-providers/#history