### PR TITLE
Add run_moderation Method

### DIFF
--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/__init__.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/__init__.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from llama_stack.distribution.datatypes import AccessRule, Api
+from llama_stack.apis.datatypes import AccessRule, Api
 
 from .config import LightspeedAgentsImplConfig
 

--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agent_instance.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agent_instance.py
@@ -3,7 +3,7 @@ import uuid
 from collections.abc import AsyncGenerator
 
 from llama_stack.apis.agents import AgentConfig, AgentTurnCreateRequest, StepType
-from llama_stack.distribution.datatypes import AccessRule
+from llama_stack.apis.datatypes import AccessRule
 from llama_stack.log import get_logger
 from llama_stack.providers.inline.agents.meta_reference.agent_instance import ChatAgent
 from llama_stack.providers.utils.telemetry import tracing

--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
@@ -9,7 +9,7 @@ from llama_stack.apis.inference import Inference
 from llama_stack.apis.safety import Safety
 from llama_stack.apis.tools import ToolGroups, ToolRuntime
 from llama_stack.apis.vector_io import VectorIO
-from llama_stack.distribution.datatypes import AccessRule
+from llama_stack.apis.datatypes import AccessRule
 
 from .config import LightspeedAgentsImplConfig
 

--- a/lightspeed_stack_providers/providers/inline/safety/lightspeed_question_validity/safety.py
+++ b/lightspeed_stack_providers/providers/inline/safety/lightspeed_question_validity/safety.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from typing import Any
 from string import Template
 
@@ -7,13 +8,17 @@ from lightspeed_stack_providers.providers.inline.safety.lightspeed_question_vali
 )
 
 from llama_stack.apis.shields import Shield
-from llama_stack.distribution.datatypes import Api
+from llama_stack.apis.datatypes import Api
 from llama_stack.providers.datatypes import ShieldsProtocolPrivate
 from llama_stack.apis.safety import (
     SafetyViolation,
     ViolationLevel,
     RunShieldResponse,
     Safety,
+)
+from llama_stack.apis.safety.safety import (
+    ModerationObject,
+    ModerationObjectResults,
 )
 from llama_stack.apis.inference import (
     Inference,
@@ -43,6 +48,64 @@ class QuestionValidityShieldImpl(Safety, ShieldsProtocolPrivate):
 
     async def register_shield(self, shield: Shield) -> None:
         pass
+
+    async def run_moderation(self, input: str | list[str], model: str) -> ModerationObject:
+        """Run moderation on input text to check if it's a valid question."""
+        inputs = input if isinstance(input, list) else [input]
+        results = []
+
+        for text_input in inputs:
+            log.info(f"Running QuestionValidityShield moderation on input: {text_input[:100]}...")
+            try:
+                user_msg = UserMessage(content=text_input)
+                
+                impl = QuestionValidityRunner(
+                    model_id=self.config.model_id,
+                    model_prompt_template=self.model_prompt_template,
+                    invalid_question_response=self.config.invalid_question_response,
+                    inference_api=self.inference_api,
+                )
+
+                run_shield_response = await impl.run(user_msg)
+                moderation_result = self._get_moderation_object_results(run_shield_response)
+                
+            except Exception as e:
+                log.error(f"QuestionValidityShield moderation failed: {e}")
+                # Create safe fallback response on failure to avoid blocking legitimate requests
+                moderation_result = ModerationObjectResults(
+                    flagged=False,
+                    categories={},
+                    category_scores={},
+                    category_applied_input_types={},
+                    user_message=None,
+                    metadata={"moderation_error": str(e)},
+                )
+            results.append(moderation_result)
+
+        return ModerationObject(id=str(uuid.uuid4()), model=model, results=results)
+
+    def _get_moderation_object_results(self, run_shield_response: RunShieldResponse) -> ModerationObjectResults:
+        """Convert RunShieldResponse to ModerationObjectResults."""
+        if run_shield_response.violation is None:
+            # Safe result - question is valid
+            return ModerationObjectResults(
+                flagged=False,
+                categories={},
+                category_scores={"question_validity": 0.0},
+                category_applied_input_types={},
+                user_message=None,
+                metadata={},
+            )
+        else:
+            # Unsafe result - question is invalid
+            return ModerationObjectResults(
+                flagged=True,
+                categories={"question_validity": run_shield_response.violation.violation_level.value},
+                category_scores={"question_validity": 1.0},
+                category_applied_input_types={"question_validity": "text"},
+                user_message=run_shield_response.violation.user_message,
+                metadata={"violation_level": run_shield_response.violation.violation_level.value},
+            )
 
     async def run_shield(
         self,

--- a/lightspeed_stack_providers/providers/inline/safety/lightspeed_redaction/lightspeed_redaction/redaction.py
+++ b/lightspeed_stack_providers/providers/inline/safety/lightspeed_redaction/lightspeed_redaction/redaction.py
@@ -8,7 +8,7 @@ from lightspeed_stack_providers.providers.inline.safety.lightspeed_redaction.con
 )
 
 from llama_stack.apis.shields import Shield
-from llama_stack.distribution.datatypes import Api
+from llama_stack.apis.datatypes import Api
 from llama_stack.providers.datatypes import ShieldsProtocolPrivate
 from llama_stack.apis.safety import (
     RunShieldResponse,

--- a/lightspeed_stack_providers/providers/remote/tool_runtime/lightspeed/__init__.py
+++ b/lightspeed_stack_providers/providers/remote/tool_runtime/lightspeed/__init__.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from pydantic import BaseModel
 
-from llama_stack.distribution.datatypes import Api
+from llama_stack.apis.datatypes import Api
 
 
 from .config import LightspeedToolConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "lightspeed_stack_providers"
 version = "0.1.15"
 description = "Lightspeed Stack providers for llama-stack"
 requires-python = ">=3.12"
-dependencies = ["llama-stack==0.2.16", "httpx", "pydantic>=2.10.6"]
+dependencies = ["llama-stack==0.2.18", "httpx", "pydantic>=2.10.6"]
 
 [tool.setuptools.packages]
 find = {}


### PR DESCRIPTION
- Adds the `run_moderation` method, allowing these Shields to be used in Llama Stack versions `0.2.17` and above. 
