### PR TITLE
[RHDHPAI-1149] Update Validation To Consume Llama Stack 0.2.18

### DIFF
--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/__init__.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/__init__.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from llama_stack.distribution.datatypes import AccessRule, Api
+from llama_stack.apis.datatypes import AccessRule, Api
 
 from .config import LightspeedAgentsImplConfig
 

--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agent_instance.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agent_instance.py
@@ -3,7 +3,7 @@ import uuid
 from collections.abc import AsyncGenerator
 
 from llama_stack.apis.agents import AgentConfig, AgentTurnCreateRequest, StepType
-from llama_stack.distribution.datatypes import AccessRule
+from llama_stack.apis.datatypes import AccessRule
 from llama_stack.log import get_logger
 from llama_stack.providers.inline.agents.meta_reference.agent_instance import ChatAgent
 from llama_stack.providers.utils.telemetry import tracing

--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
@@ -9,7 +9,7 @@ from llama_stack.apis.inference import Inference
 from llama_stack.apis.safety import Safety
 from llama_stack.apis.tools import ToolGroups, ToolRuntime
 from llama_stack.apis.vector_io import VectorIO
-from llama_stack.distribution.datatypes import AccessRule
+from llama_stack.apis.datatypes import AccessRule
 
 from .config import LightspeedAgentsImplConfig
 

--- a/lightspeed_stack_providers/providers/inline/safety/lightspeed_question_validity/safety.py
+++ b/lightspeed_stack_providers/providers/inline/safety/lightspeed_question_validity/safety.py
@@ -7,13 +7,17 @@ from lightspeed_stack_providers.providers.inline.safety.lightspeed_question_vali
 )
 
 from llama_stack.apis.shields import Shield
-from llama_stack.distribution.datatypes import Api
+from llama_stack.apis.datatypes import Api
 from llama_stack.providers.datatypes import ShieldsProtocolPrivate
 from llama_stack.apis.safety import (
     SafetyViolation,
     ViolationLevel,
     RunShieldResponse,
     Safety,
+)
+from llama_stack.apis.safety.safety import (
+    ModerationObject,
+    ModerationObjectResults,
 )
 from llama_stack.apis.inference import (
     Inference,
@@ -34,7 +38,6 @@ class QuestionValidityShieldImpl(Safety, ShieldsProtocolPrivate):
         self.config = config
         self.model_prompt_template = Template(f"{self.config.model_prompt}")
         self.inference_api = deps[Api.inference]
-        self.shield_store = {}
 
     async def initialize(self) -> None:
         pass
@@ -42,23 +45,14 @@ class QuestionValidityShieldImpl(Safety, ShieldsProtocolPrivate):
     async def shutdown(self) -> None:
         pass
 
-    async def register_shield(self, shield: Shield) -> None:
-        self.shield_store[shield.identifier] = shield
-
-    async def run_shield(
-        self,
-        shield_id: str,
-        messages: list[Message],
-        params: dict[str, Any] = None,
-    ) -> RunShieldResponse:
-        shield = self.shield_store.get(shield_id)
-        if not shield:
-            raise ValueError(f"Unknown shield {shield_id}")
-
-        messages = messages.copy()
-        # [TODO] manstis: Ensure this is the latest User message
-        message: UserMessage = messages[len(messages) - 1 :][0]
-        log.debug(f"Shield UserMessage: {message.content}")
+    async def run_moderation(
+        self, input: str | list[str], model: str
+    ) -> ModerationObject:
+        """Run moderation on input text to check if it's a valid question."""
+        if isinstance(input, list):
+            text = " ".join(input)
+        else:
+            text = input
 
         impl = QuestionValidityRunner(
             model_id=self.config.model_id,
@@ -67,7 +61,54 @@ class QuestionValidityShieldImpl(Safety, ShieldsProtocolPrivate):
             inference_api=self.inference_api,
         )
 
+        run_response = await impl.run(UserMessage(content=text))
+        return self._get_moderation_object_results(run_response)
+
+    def _get_moderation_object_results(
+        self, run_shield_response: RunShieldResponse
+    ) -> ModerationObjectResults:
+        """Convert RunShieldResponse to ModerationObjectResults."""
+        if run_shield_response.violation is None:
+            return ModerationObjectResults(
+                flagged=False,
+                categories={},
+                category_scores={"question_validity": 0.0},
+                category_applied_input_types={},
+                user_message=None,
+                metadata={},
+            )
+        else:
+            return ModerationObjectResults(
+                flagged=True,
+                categories={
+                    "question_validity": run_shield_response.violation.violation_level.value
+                },
+                category_scores={"question_validity": 1.0},
+                category_applied_input_types={"question_validity": "text"},
+                user_message=run_shield_response.violation.user_message,
+                metadata={
+                    "violation_level": run_shield_response.violation.violation_level.value
+                },
+            )
+
+    async def run_shield(
+        self,
+        shield_id: str,
+        messages: list[Message],
+        params: dict[str, Any] = None,
+    ) -> RunShieldResponse:
+        # Take last UserMessage
+        message: UserMessage = [m for m in messages if isinstance(m, UserMessage)][-1]
+        log.debug(f"Shield UserMessage: {message.content}")
+
+        impl = QuestionValidityRunner(
+            model_id=self.config.model_id,
+            model_prompt_template=self.model_prompt_template,
+            invalid_question_response=self.config.invalid_question_response,
+            inference_api=self.inference_api,
+        )
         return await impl.run(message)
+
 
 
 class QuestionValidityRunner:

--- a/lightspeed_stack_providers/providers/inline/safety/lightspeed_question_validity/safety.py
+++ b/lightspeed_stack_providers/providers/inline/safety/lightspeed_question_validity/safety.py
@@ -110,7 +110,6 @@ class QuestionValidityShieldImpl(Safety, ShieldsProtocolPrivate):
         return await impl.run(message)
 
 
-
 class QuestionValidityRunner:
     def __init__(
         self,

--- a/lightspeed_stack_providers/providers/inline/safety/lightspeed_redaction/lightspeed_redaction/redaction.py
+++ b/lightspeed_stack_providers/providers/inline/safety/lightspeed_redaction/lightspeed_redaction/redaction.py
@@ -8,7 +8,7 @@ from lightspeed_stack_providers.providers.inline.safety.lightspeed_redaction.con
 )
 
 from llama_stack.apis.shields import Shield
-from llama_stack.distribution.datatypes import Api
+from llama_stack.apis.datatypes import Api
 from llama_stack.providers.datatypes import ShieldsProtocolPrivate
 from llama_stack.apis.safety import (
     RunShieldResponse,

--- a/lightspeed_stack_providers/providers/remote/tool_runtime/lightspeed/__init__.py
+++ b/lightspeed_stack_providers/providers/remote/tool_runtime/lightspeed/__init__.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 from pydantic import BaseModel
 
-from llama_stack.distribution.datatypes import Api
+from llama_stack.apis.datatypes import Api
 
 
 from .config import LightspeedToolConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "lightspeed_stack_providers"
 version = "0.1.15"
 description = "Lightspeed Stack providers for llama-stack"
 requires-python = ">=3.12"
-dependencies = ["llama-stack==0.2.16", "httpx", "pydantic>=2.10.6", "litellm>=1.75.5.post1", "sqlalchemy>=2.0.0"]
+dependencies = ["llama-stack==0.2.18", "httpx", "pydantic>=2.10.6", "litellm>=1.75.5.post1", "sqlalchemy>=2.0.0"]
 
 [tool.setuptools.packages]
 find = {}

--- a/resources/external_providers/inline/safety/lightspeed_question_validity.yaml
+++ b/resources/external_providers/inline/safety/lightspeed_question_validity.yaml
@@ -3,6 +3,5 @@ config_class: lightspeed_stack_providers.providers.inline.safety.lightspeed_ques
 pip_packages: ["lightspeed_stack_providers"]
 api_dependencies:
   - inference
-  - safety
 optional_api_dependencies: []
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -725,7 +725,7 @@ test = [
 requires-dist = [
     { name = "httpx" },
     { name = "litellm", specifier = ">=1.75.5.post1" },
-    { name = "llama-stack", specifier = "==0.2.16" },
+    { name = "llama-stack", specifier = "==0.2.18" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
 ]
@@ -785,7 +785,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack"
-version = "0.2.16"
+version = "0.2.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -815,14 +815,14 @@ dependencies = [
     { name = "tiktoken" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/76/3d73f4bfcf34ef7c703f3f3cfbe635f500b044c78fd33302199dce3ac698/llama_stack-0.2.16.tar.gz", hash = "sha256:e1ffb5400c85bf23b97f8f48028cb85061bb87a72b741faace1a174215f5de32", size = 3284603, upload-time = "2025-07-28T23:13:32.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/e1/16c52856746e1412274c085a6e6a21829133f9db3d4932a009700594f4a2/llama_stack-0.2.18.tar.gz", hash = "sha256:0ea6e150140047568e45f98100027a79e20340711e5feff083d9b9dfe42d2605", size = 3321726, upload-time = "2025-08-19T22:12:17.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/36/35cc221603aa7c23efb41a88dd7c122af96740f50191d1da0ab9dc74056d/llama_stack-0.2.16-py3-none-any.whl", hash = "sha256:b9313acb150360467d7cccb54adb160b2fd585b7ab2505e88b5320c6bf766efe", size = 3603056, upload-time = "2025-07-28T23:13:30.731Z" },
+    { url = "https://files.pythonhosted.org/packages/65/72/c68c50be2d2808fe162c3f344f976bc29839f0cee7a6d951cc3805f8482d/llama_stack-0.2.18-py3-none-any.whl", hash = "sha256:3383fb4da1cc6e77a58ae425ef49ce470bca784ca85051dd6b2b70966f936bea", size = 3650850, upload-time = "2025-08-19T22:12:15.857Z" },
 ]
 
 [[package]]
 name = "llama-stack-client"
-version = "0.2.16"
+version = "0.2.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -841,9 +841,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/28/74ae2faae9af51205587b33fcf2f99a8af090de7aa4122701f2f70f04233/llama_stack_client-0.2.16.tar.gz", hash = "sha256:24294acc6bf40e79900a62f4fa61009acb9af7028b198b12c0ba8adab25c2049", size = 257642, upload-time = "2025-07-28T23:13:22.793Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/8f/306d5fcf2f97b3a6251219b03c194836a2ff4e0fcc8146c9970e50a72cd3/llama_stack_client-0.2.23.tar.gz", hash = "sha256:68f34e8ac8eea6a73ed9d4977d849992b2d8bd835804d770a11843431cd5bf74", size = 322288, upload-time = "2025-09-26T21:11:08.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/ec/1874120a15b22f3a88d4e49700c870cc6540bc8c709a841db79a662d7949/llama_stack_client-0.2.16-py3-none-any.whl", hash = "sha256:5c0d13e6ac40143ce01cae4eec65fb39fe24e11f54b86afbd20f0033c38f83c0", size = 350329, upload-time = "2025-07-28T23:13:21.586Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/75/3eb58e092a681804013dbec7b7f549d18f55acf6fd6e6b27de7e249766d8/llama_stack_client-0.2.23-py3-none-any.whl", hash = "sha256:eee42c74eee8f218f9455e5a06d5d4be43f8a8c82a7937ef51ce367f916df847", size = 379809, upload-time = "2025-09-26T21:11:06.856Z" },
 ]
 
 [[package]]
@@ -1048,7 +1048,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "1.108.1"
+version = "1.99.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1060,9 +1060,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/7a/3f2fbdf82a22d48405c1872f7c3176a705eee80ff2d2715d29472089171f/openai-1.108.1.tar.gz", hash = "sha256:6648468c1aec4eacfa554001e933a9fa075f57bacfc27588c2e34456cee9fef9", size = 563735, upload-time = "2025-09-19T16:52:20.399Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/d2/ef89c6f3f36b13b06e271d3cc984ddd2f62508a0972c1cbcc8485a6644ff/openai-1.99.9.tar.gz", hash = "sha256:f2082d155b1ad22e83247c3de3958eb4255b20ccf4a1de2e6681b6957b554e92", size = 506992, upload-time = "2025-08-12T02:31:10.054Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/87/6ad18ce0e7b910e3706480451df48ff9e0af3b55e5db565adafd68a0706a/openai-1.108.1-py3-none-any.whl", hash = "sha256:952fc027e300b2ac23be92b064eac136a2bc58274cec16f5d2906c361340d59b", size = 948394, upload-time = "2025-09-19T16:52:18.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/fb/df274ca10698ee77b07bff952f302ea627cc12dac6b85289485dd77db6de/openai-1.99.9-py3-none-any.whl", hash = "sha256:9dbcdb425553bae1ac5d947147bebbd630d91bbfc7788394d4c4f3a35682ab3a", size = 786816, upload-time = "2025-08-12T02:31:08.34Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description
This PR:
- Updates imports to use the `apis` syntax instead of `distribution`.
- Adds `run_moderation` method to allow Llama Stack >= 0.2.18 to be used, they moved away from `run_shield` and to `run_moderation`.
- Removes `safety` api dependency in the `.yaml` file, our provider inherits `Safety` and as such does not need access to its api, this creates a circular dependency and errors out the provider when run.
- Bumps Llama Stack version to `0.2.18`

# Related Issue

https://issues.redhat.com/browse/RHDHPAI-1149