### PR TITLE
fix: use sqlalchemy[asyncio] to ensure greenlet on all platforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "httpx",
     "pydantic>=2.10.6",
     "litellm>=1.75.5.post1",
-    "sqlalchemy>=2.0.0",
+    "sqlalchemy[asyncio]>=2.0.0",
     "mcp",
 ]
 


### PR DESCRIPTION
## Description

Use `sqlalchemy[asyncio]>=2.0.0` instead of `sqlalchemy>=2.0.0` to ensure greenlet is installed on all platforms.

SQLAlchemy's base dependencies specify greenlet with platform markers that exclude s390x. Since we use async SQLAlchemy features (via llama-stack), we need greenlet at runtime on all platforms.

The `[asyncio]` extra includes greenlet unconditionally, fixing s390x builds that were failing with "No module named 'greenlet'".

## Type of change

- [x] Bug fix

## Tools used to create PR

- Assisted-by: Claude Code
- Generated by: Claude Opus 4.5

## Related Tickets & Documents

- Related Issue # N/A
- Closes # N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- Verify s390x container build succeeds with greenlet properly installed via sqlalchemy[asyncio] dependency.