### PR TITLE
[release-0.4] remove max_tokens from tools filtering

### DIFF
--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
@@ -249,7 +249,6 @@ class LightspeedAgentsImpl(MetaReferenceAgentsImpl):
             ],
             stream=False,
             temperature=0.1,
-            max_tokens=2048,
         )
         response = await self.inference_api.openai_chat_completion(request)
 


### PR DESCRIPTION
Backport to release-0.4 branch 

(cherry picked from commit 82032693d675e2c7af7cb6fee20338d0aeabdc1b)

## Description

gpt-5 forces use max_completion_tokens and fails when max_tokens is set, we want neutral api, and we cannot predict which model is using what, even if we know that gpt-4o-mini accept max_tokens and max_completion_tokens granite models uses max_tokens but ignor max_completion_tokens. Think it's safe to remove max_tokens as long as we explicitly set max 10 tools to return in the prompt that maybe than 1000 tokens. 

issues: https://redhat.atlassian.net/browse/AAP-70396

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
