### PR TITLE
LCORE-1396: fix e2e tests

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -65,26 +65,18 @@ jobs:
               - provider_id: lightspeed_question_validity
                 provider_type: inline::lightspeed_question_validity
                 config:
-                  model_id: openai/gpt-4o
+                  model_id: openai/gpt-4o-mini
                   temperature: 0.0
-                  invalid_question_response: |
-                    Hi, I'm the OpenShift Lightspeed assistant, I can help you with questions about OpenShift, 
-                    please ask me a question related to OpenShift.
-          
-          models:
-            - model_id: gpt-4o
-              provider_id: openai
-              model_type: llm
-              provider_model_id: gpt-4o
-          
-          shields:
-            - shield_id: lightspeed_question_validity-shield
-              provider_id: lightspeed_question_validity
-          
+
+          registered_resources:
+            shields:
+              - shield_id: lightspeed_question_validity-shield
+                provider_id: lightspeed_question_validity
+
           server:
             host: 0.0.0.0
             port: 8321
-          
+
           logging:
             level: DEBUG
           EOF

--- a/lightspeed_stack_providers/providers/inline/safety/lightspeed_question_validity/safety.py
+++ b/lightspeed_stack_providers/providers/inline/safety/lightspeed_question_validity/safety.py
@@ -1,7 +1,6 @@
 import logging
 import uuid
 from string import Template
-from typing import Any
 
 from llama_stack_api import (
     Api,
@@ -9,11 +8,11 @@ from llama_stack_api import (
     ModerationObject,
     ModerationObjectResults,
     RunModerationRequest,
+    RunShieldRequest,
     RunShieldResponse,
     Safety,
     SafetyViolation,
     ShieldsProtocolPrivate,
-    UserMessage,
     ViolationLevel,
 )
 from llama_stack_api.inference import (
@@ -103,7 +102,9 @@ class QuestionValidityShieldImpl(Safety, ShieldsProtocolPrivate):
         )
 
         for text in inputs:
-            run_response = await impl.run(UserMessage(content=text))
+            run_response = await impl.run(
+                OpenAIUserMessageParam(role="user", content=text)
+            )
             results.append(self._get_moderation_object_results(run_response))
 
         return ModerationObject(
@@ -156,11 +157,9 @@ class QuestionValidityShieldImpl(Safety, ShieldsProtocolPrivate):
 
     async def run_shield(
         self,
-        shield_id: str,
-        messages: list[Message],
-        params: dict[str, Any] = None,
+        request: RunShieldRequest,
     ) -> RunShieldResponse:
-        # Take last user message (can be UserMessage or OpenAIUserMessageParam)
+        # Take last user message (OpenAIUserMessageParam)
         """
         Run the question-validity shield against the most recent user message in the message list.
 
@@ -170,29 +169,27 @@ class QuestionValidityShieldImpl(Safety, ShieldsProtocolPrivate):
         indicating no violation.
 
         Parameters:
-            - shield_id (str): Identifier of the shield being invoked.
-            - messages (list[Message]): A sequence of message objects (may
-              contain different message param types); the last message with
-              role "user" or a user message type will be evaluated.
-            - params (dict[str, Any], optional): Additional runtime parameters
-              (currently unused by this implementation).
+            - request (RunShieldRequest): Request containing shield_id and
+              messages; the last message with role "user" or a user message
+              type will be evaluated.
 
         Returns:
             RunShieldResponse: `violation=None` if no user message was found;
             otherwise the shield's decision for the evaluated user message.
         """
+        messages = request.messages
         user_messages = [
             m
             for m in messages
-            if isinstance(m, (UserMessage, OpenAIUserMessageParam))
+            if isinstance(m, OpenAIUserMessageParam)
             or (hasattr(m, "role") and m.role == "user")
         ]
         if not user_messages:
             return RunShieldResponse(violation=None)
         last_msg = user_messages[-1]
         content = last_msg.content if hasattr(last_msg, "content") else str(last_msg)
-        message = UserMessage(content=content)
-        log.debug(f"Shield UserMessage: {message.content}")
+        message = OpenAIUserMessageParam(role="user", content=content)
+        log.debug(f"Shield message: {message.content}")
 
         impl = QuestionValidityRunner(
             model_id=self.config.model_id,
@@ -229,19 +226,21 @@ class QuestionValidityRunner:
         self.invalid_question_response = invalid_question_response
         self.inference_api = inference_api
 
-    def build_text_shield_input(self, message: UserMessage) -> UserMessage:
+    def build_text_shield_input(
+        self, message: OpenAIUserMessageParam
+    ) -> OpenAIUserMessageParam:
         """
-        Create a UserMessage whose content is the shield prompt generated from the provided message.
+        Create a message whose content is the shield prompt generated from the provided message.
 
         Parameters:
-            message (UserMessage): The original user message to base the shield prompt on.
+            message (OpenAIUserMessageParam): The original user message to base the shield prompt on.
 
         Returns:
-            UserMessage: A new UserMessage containing the generated shield prompt as its content.
+            OpenAIUserMessageParam: A new message containing the generated shield prompt as its content.
         """
-        return UserMessage(content=self.build_prompt(message))
+        return OpenAIUserMessageParam(role="user", content=self.build_prompt(message))
 
-    def build_prompt(self, message: UserMessage) -> str:
+    def build_prompt(self, message: OpenAIUserMessageParam) -> str:
         """
         Builds the shield prompt.
 
@@ -249,8 +248,8 @@ class QuestionValidityRunner:
         the message content and subject tokens.
 
         Parameters:
-            - message (UserMessage): The user message whose content will be
-              inserted into the template as `message`.
+            - message (OpenAIUserMessageParam): The user message whose content
+              will be inserted into the template as `message`.
 
         Returns:
             str: The prompt string with `allowed`, `rejected`, and `message` values substituted.
@@ -292,7 +291,7 @@ class QuestionValidityRunner:
             ),
         )
 
-    async def run(self, message: UserMessage) -> RunShieldResponse:
+    async def run(self, message: OpenAIUserMessageParam) -> RunShieldResponse:
         """
         Run the question-validity shield.
 

--- a/lightspeed_stack_providers/providers/inline/safety/lightspeed_redaction/lightspeed_redaction/redaction.py
+++ b/lightspeed_stack_providers/providers/inline/safety/lightspeed_redaction/lightspeed_redaction/redaction.py
@@ -1,12 +1,13 @@
 import logging
 import re
 import uuid
-from typing import Any, Optional
+from typing import Any
 
 from llama_stack_api import (
     ModerationObject,
     ModerationObjectResults,
     RunModerationRequest,
+    RunShieldRequest,
     RunShieldResponse,
     Safety,
     Shield,
@@ -113,9 +114,7 @@ class RedactionShieldImpl(Safety, ShieldsProtocolPrivate):
 
     async def run_shield(
         self,
-        shield_id: str,
-        messages: list[Message],
-        params: Optional[dict[str, Any]] = None,
+        request: RunShieldRequest,
     ) -> RunShieldResponse:
         """Run the redaction shield - mutates messages directly.
 
@@ -126,15 +125,14 @@ class RedactionShieldImpl(Safety, ShieldsProtocolPrivate):
         replaced with the redacted string.
 
         Parameters:
-            - shield_id (str): Identifier for the shield invocation.
-            - messages (list[Message]): Messages to process; any message with a
-              string `content` may be mutated in place.
-            - params (Optional[dict[str, Any]]): Optional execution parameters
-              (not required by this implementation).
+            - request (RunShieldRequest): Request containing shield_id and
+              messages; any message with a string `content` may be mutated
+              in place.
 
         Returns:
             RunShieldResponse: A response object; `violation` is `None` for this implementation.
         """
+        messages = request.messages
         for message in messages:
             if hasattr(message, "content") and isinstance(message.content, str):
                 original_content: str = message.content

--- a/tests/unit/providers/inline/safety/lightspeed_question_validity/test_safety_question_validity.py
+++ b/tests/unit/providers/inline/safety/lightspeed_question_validity/test_safety_question_validity.py
@@ -4,7 +4,8 @@ from string import Template
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from llama_stack_api import RunModerationRequest, UserMessage
+from llama_stack_api import RunModerationRequest, RunShieldRequest
+from llama_stack_api.inference import OpenAIUserMessageParam
 from llama_stack_api.safety import RunShieldResponse, SafetyViolation, ViolationLevel
 from pytest_mock import MockerFixture
 
@@ -72,7 +73,9 @@ def create_mock_chat_response(content: str) -> MagicMock:
 
 def test_build_prompt(question_validity_runner: QuestionValidityRunner) -> None:
     """Test that the prompt is built correctly."""
-    message = UserMessage(content="How do I create a Kubernetes service?")
+    message = OpenAIUserMessageParam(
+        role="user", content="How do I create a Kubernetes service?"
+    )
     prompt = question_validity_runner.build_prompt(message)
     assert "Is this question allowed?" in prompt
     assert SUBJECT_ALLOWED in prompt
@@ -107,7 +110,9 @@ async def test_run_allowed(
     question_validity_runner: QuestionValidityRunner, mock_inference_api: AsyncMock
 ) -> None:
     """Test the run method for an allowed question."""
-    message = UserMessage(content="How do I create a Kubernetes service?")
+    message = OpenAIUserMessageParam(
+        role="user", content="How do I create a Kubernetes service?"
+    )
     mock_inference_api.openai_chat_completion.return_value = create_mock_chat_response(
         SUBJECT_ALLOWED
     )
@@ -123,7 +128,7 @@ async def test_run_rejected(
     question_validity_runner: QuestionValidityRunner, mock_inference_api: AsyncMock
 ) -> None:
     """Test the run method for a rejected question."""
-    message = UserMessage(content="What is the weather today?")
+    message = OpenAIUserMessageParam(role="user", content="What is the weather today?")
     mock_inference_api.openai_chat_completion.return_value = create_mock_chat_response(
         SUBJECT_REJECTED
     )
@@ -164,16 +169,14 @@ async def test_run_shield_allowed(
     mock_runner.return_value.run = mocker.AsyncMock(
         return_value=RunShieldResponse(violation=None)
     )
-    # Use OpenAI message format
-    from llama_stack_api.inference import OpenAIUserMessageParam
-
     messages = [
         OpenAIUserMessageParam(
             role="user", content="How do I create a Kubernetes service?"
         )
     ]
+    request = RunShieldRequest(shield_id="test_shield", messages=messages)
 
-    response = await question_validity_shield_impl.run_shield("test_shield", messages)
+    response = await question_validity_shield_impl.run_shield(request)
 
     assert response.violation is None
     mock_runner.return_value.run.assert_called_once()
@@ -195,14 +198,12 @@ async def test_run_shield_rejected(
             )
         )
     )
-    # Use OpenAI message format
-    from llama_stack_api.inference import OpenAIUserMessageParam
-
     messages = [
         OpenAIUserMessageParam(role="user", content="What is the weather today?")
     ]
+    request = RunShieldRequest(shield_id="test_shield", messages=messages)
 
-    response = await question_validity_shield_impl.run_shield("test_shield", messages)
+    response = await question_validity_shield_impl.run_shield(request)
 
     assert isinstance(response.violation, SafetyViolation)
     mock_runner.return_value.run.assert_called_once()

--- a/tests/unit/providers/inline/safety/lightspeed_redaction/lightspeed_redaction/test_redaction_redaction.py
+++ b/tests/unit/providers/inline/safety/lightspeed_redaction/lightspeed_redaction/test_redaction_redaction.py
@@ -1,7 +1,8 @@
 """Unit tests for Lightspeed redaction provider behaviour."""
 
 import pytest
-from llama_stack_api.inference import UserMessage
+from llama_stack_api import RunShieldRequest
+from llama_stack_api.inference import OpenAIUserMessageParam
 
 from lightspeed_stack_providers.providers.inline.safety.lightspeed_redaction.lightspeed_redaction.config import (
     PatternReplacement,
@@ -62,8 +63,11 @@ def test_apply_redaction_rules_case_insensitive(
 async def test_run_shield(redaction_shield_impl: RedactionShieldImpl) -> None:
     """Test the run_shield method."""
     messages: list[Message] = [
-        UserMessage(content="This is a secret message from 2023.")
+        OpenAIUserMessageParam(
+            role="user", content="This is a secret message from 2023."
+        )
     ]
-    response = await redaction_shield_impl.run_shield("test_shield", messages)
+    request = RunShieldRequest(shield_id="test_shield", messages=messages)
+    response = await redaction_shield_impl.run_shield(request)
     assert response.violation is None
     assert messages[0].content == "This is a [REDACTED] message from [YEAR]."


### PR DESCRIPTION
## Description
Fixed E2E tests by:
- fixed 400 by updating run.yaml in e2e_tests.yaml
- fixed 500 by updating safety providers to use `RunShieldRequest`

Also removed use of `UserMessage` as the standard has become the `OpenAIUserMessageParam`.

## Type of change

- [X] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [X] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
E2E tests were confirmed to be working through [personal feature branch](https://github.com/jrobertboos/lightspeed-providers/actions/runs/24215600605/job/70695239570) successful actions