### PR TITLE
RHOKP-1361: enable deep link URL fields

### DIFF
--- a/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/config.py
+++ b/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/config.py
@@ -59,9 +59,13 @@ class ChunkWindowConfig(BaseModel):
         default=None,
         description="Field name for content title in parent documents (e.g. 'title')",
     )
-    parent_content_url_field: Optional[str] = Field(
+    chunk_online_source_url_field: Optional[str] = Field(
         default=None,
-        description="Field name for content URL in parent documents (e.g. 'reference_url')",
+        description="Solr field name for per-chunk online URL (e.g. 'online_source_url')",
+    )
+    chunk_source_path_field: Optional[str] = Field(
+        default=None,
+        description="Solr field name for per-chunk offline relative path (e.g. 'source_path')",
     )
 
     # ---- Query filters ----
@@ -202,7 +206,8 @@ class SolrVectorIOConfig(BaseModel):
             #   "parent_total_tokens_field": "total_tokens",
             #   "parent_content_id_field": "doc_id",
             #   "parent_content_title_field": "title",
-            #   "parent_content_url_field": "reference_url",
+            #   "chunk_online_source_url_field": "online_source_url",
+            #   "chunk_source_path_field": "source_path",
             #   "chunk_filter_query": "is_chunk:true",
             #   "family_token_budget": 3072,
             #   "orphan_token_budget": 1536,

--- a/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/solr.py
+++ b/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/solr.py
@@ -522,8 +522,6 @@ class SolrIndex(EmbeddingIndex):
             fields.append(schema.parent_content_id_field)
         if schema.parent_content_title_field:
             fields.append(schema.parent_content_title_field)
-        if schema.parent_content_url_field:
-            fields.append(schema.parent_content_url_field)
 
         try:
             log.info(f"Fetching parent metadata for parent_id={parent_id}")
@@ -861,11 +859,6 @@ class SolrIndex(EmbeddingIndex):
                     if title:
                         expanded_metadata["title"] = title
 
-                if schema.parent_content_url_field:
-                    url = parent_doc.get(schema.parent_content_url_field)
-                    if url:
-                        expanded_metadata["reference_url"] = url
-
                 expanded_metadata["source"] = OKP_SOURCE
 
                 # Create expanded chunk
@@ -1024,8 +1017,20 @@ class SolrIndex(EmbeddingIndex):
             # helpful extras if present
             if "title" in doc:
                 metadata["title"] = doc["title"]
-            if "reference_url" in doc:
-                metadata["reference_url"] = doc["reference_url"]
+            if (
+                self.chunk_window_config
+                and self.chunk_window_config.chunk_online_source_url_field
+            ):
+                url_field = self.chunk_window_config.chunk_online_source_url_field
+                if url_field in doc:
+                    metadata["reference_url"] = doc[url_field]
+            if (
+                self.chunk_window_config
+                and self.chunk_window_config.chunk_source_path_field
+            ):
+                path_field = self.chunk_window_config.chunk_source_path_field
+                if path_field in doc:
+                    metadata["source_path"] = doc[path_field]
             if "resourceName" in doc:
                 metadata["resourceName"] = doc["resourceName"]
             if "chunk_index" in doc:

--- a/tests/unit/providers/remote/solr_vector_io/test_doc_to_chunk.py
+++ b/tests/unit/providers/remote/solr_vector_io/test_doc_to_chunk.py
@@ -35,11 +35,12 @@ def chunk_window_config():
         chunk_index_field="chunk_index",
         chunk_content_field="chunk",
         chunk_token_count_field="num_tokens",
+        chunk_online_source_url_field="online_source_url",
+        chunk_source_path_field="source_path",
         parent_total_chunks_field="total_chunks",
         parent_total_tokens_field="total_tokens",
         parent_content_id_field="doc_id",
         parent_content_title_field="title",
-        parent_content_url_field="reference_url",
     )
 
 
@@ -128,12 +129,19 @@ class TestOptionalFields:
         assert chunk is not None
         assert "title" not in chunk.metadata
 
-    def test_reference_url_included_when_present(self, solr_index):
+    def test_online_source_url_mapped_to_reference_url(self, solr_index):
         chunk = solr_index._doc_to_chunk(
-            _basic_doc(reference_url="https://example.com/doc")
+            _basic_doc(online_source_url="https://example.com/doc#chunk1")
         )
         assert chunk is not None
-        assert chunk.metadata["reference_url"] == "https://example.com/doc"
+        assert chunk.metadata["reference_url"] == "https://example.com/doc#chunk1"
+
+    def test_source_path_included_when_present(self, solr_index):
+        chunk = solr_index._doc_to_chunk(
+            _basic_doc(source_path="/docs/install.html#step-3")
+        )
+        assert chunk is not None
+        assert chunk.metadata["source_path"] == "/docs/install.html#step-3"
 
     def test_token_count_included_when_present(self, solr_index):
         chunk = solr_index._doc_to_chunk(_basic_doc(num_tokens=42))


### PR DESCRIPTION
## Description

This MR corrects multiple issues with the current Solr URL mappings, while at the same time enabling deep linking with chunk based reference urls.

Issues fixed:
- Corrected removed solr field "reference_url" this field is no longer in the Solr schema.  The new solr fields are called `online_source_url` and `source_path` for online links and offline links respectively.  Also note these are no longer on the parent document but per chunk, to allow for deep linking to the matched chunk by url anchors.

## Type of change

- [ x] Refactor
- [ x] New feature
- [ x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/RHOKP-1361

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
1. pull the latest version of the OKP image that includes deep-linked urls in chunks
2. perform an OKP rag query in "online" mode, and verify the  reference_url points to the online docs with url anchors 
3. perform an OKP rag query in "offline" mode, and verify that the reference_url points to localhost and a path that resolves to the local running OKP container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for mapping per-chunk online source URLs and offline source path fields in Solr, enabling flexible metadata extraction and improved chunk provenance tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/lightspeed-providers/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->