### PR TITLE
LCORE-1547: Reduce complexity of `_filter_tools_for_response`, ` _doc_to_chunk`, and `_apply_chunk_window_expansion`

### DIFF
--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
@@ -143,6 +143,85 @@ class LightspeedAgentsImpl(MetaReferenceAgentsImpl):
         # Call parent with modified request
         return await super().create_openai_response(modified_request)
 
+    def _extract_user_prompt(self, input: str | list[OpenAIResponseInput]) -> str:
+        """Flatten the polymorphic input arg into a plain string for the LLM prompt."""
+        if isinstance(input, str):
+            return input
+        if isinstance(input, list):
+            return "\n".join(
+                msg.get("content", "") if isinstance(msg, dict) else str(msg)
+                for msg in input
+            )
+        return str(input)
+
+    def _parse_llm_tool_names(self, content: str) -> list[str]:
+        """Extract the JSON tool-name list from a freeform LLM response string."""
+        if "[" not in content or "]" not in content:
+            return []
+        list_str = content[content.rfind("[") : content.rfind("]") + 1]
+        try:
+            names = json.loads(list_str)
+            logger.info("Filtered tool names from LLM: %s", names)
+            return names
+        except Exception as exp:
+            logger.error("Failed to parse LLM response as JSON: %s", exp)
+            return []
+
+    def _build_filtered_tool_list(
+        self,
+        tools: list[OpenAIResponseInputTool],
+        filtered_tool_names: list[str],
+        tool_to_endpoint: dict[str, str],
+    ) -> list[OpenAIResponseInputTool]:
+        """Walk tools and set allowed_tools on MCP entries; pass non-MCP tools through."""
+        result = []
+        for tool in tools:
+            tool_dict = tool if isinstance(tool, dict) else tool.model_dump()
+            tool_type = tool_dict.get("type")
+
+            if tool_type == "mcp":
+                mcp_endpoint = tool_dict.get("server_url", "")
+                server_label = tool_dict.get("server_label", "unknown")
+                logger.debug(
+                    "Processing MCP config: server_label=%s, server_url=%s",
+                    server_label,
+                    mcp_endpoint,
+                )
+                logger.debug("All filtered tool names: %s", filtered_tool_names)
+                endpoint_tools = [
+                    tool_name
+                    for tool_name in filtered_tool_names
+                    if tool_to_endpoint.get(tool_name) == mcp_endpoint
+                ]
+                logger.debug(
+                    "MCP server %s (%s): Setting allowed_tools = %s (filtered from %d total tools)",
+                    server_label,
+                    mcp_endpoint,
+                    endpoint_tools,
+                    len(filtered_tool_names),
+                )
+                if endpoint_tools:
+                    if isinstance(tool, dict):
+                        tool["allowed_tools"] = endpoint_tools
+                    else:
+                        tool.allowed_tools = endpoint_tools
+                    result.append(tool)
+                else:
+                    logger.warning(
+                        "MCP server %s (%s) has no matching tools - skipping from result",
+                        server_label,
+                        mcp_endpoint,
+                    )
+            else:
+                # Non-MCP tools (file_search, function) are always included
+                logger.debug(
+                    "Including non-MCP tool: type=%s, config=%s",
+                    tool_type,
+                    tool_dict.get("name") if tool_type == "function" else tool_type,
+                )
+                result.append(tool)
+        return result
+
     async def _filter_tools_for_response(
         self,
         input: str | list[OpenAIResponseInput],
@@ -222,20 +301,8 @@ class LightspeedAgentsImpl(MetaReferenceAgentsImpl):
             self.config.tools_filter.min_tools,
         )
 
-        # Extract user prompt text from input
-        if isinstance(input, str):
-            user_prompt = input
-        elif isinstance(input, list):
-            user_prompt = "\n".join(
-                [
-                    msg.get("content", "") if isinstance(msg, dict) else str(msg)
-                    for msg in input
-                ]
-            )
-        else:
-            user_prompt = str(input)
+        user_prompt = self._extract_user_prompt(input)
 
-        # Call LLM to filter tools
         tools_filter_model_id = self.config.tools_filter.model_id or model
         logger.debug("Using model %s for tool filtering", tools_filter_model_id)
         logger.debug("System prompt: %s", self.config.tools_filter.system_prompt)
@@ -264,89 +331,24 @@ class LightspeedAgentsImpl(MetaReferenceAgentsImpl):
         )
         response = await self.inference_api.openai_chat_completion(request)
 
-        # Parse filtered tool names from LLM response
         content: str = response.choices[0].message.content
         logger.debug("LLM filter response: %s", content)
 
-        filtered_tool_names = []
-        if "[" in content and "]" in content:
-            list_str = content[content.rfind("[") : content.rfind("]") + 1]
-            try:
-                filtered_tool_names = json.loads(list_str)
-                logger.info("Filtered tool names from LLM: %s", filtered_tool_names)
-            except Exception as exp:
-                logger.error("Failed to parse LLM response as JSON: %s", exp)
-                filtered_tool_names = []
+        filtered_tool_names = list(
+            set(self._parse_llm_tool_names(content)) | always_included_tools
+        )
 
-        # Merge always-included tools into filtered list
-        filtered_tool_names = list(set(filtered_tool_names) | always_included_tools)
+        if not filtered_tool_names:
+            logger.warning("No tools matched filtering criteria, returning empty list")
+            return []
 
-        # Filter using expanded tool definitions
-        if filtered_tool_names:
-            result = []
-            for tool in tools:
-                tool_dict = tool if isinstance(tool, dict) else tool.model_dump()
-                tool_type = tool_dict.get("type")
-
-                if tool_type == "mcp" and len(filtered_tool_names) > 0:
-                    # Get the endpoint for this MCP config
-                    mcp_endpoint = tool_dict.get("server_url", "")
-                    server_label = tool_dict.get("server_label", "unknown")
-
-                    logger.debug(
-                        "Processing MCP config: server_label=%s, server_url=%s",
-                        server_label,
-                        mcp_endpoint,
-                    )
-                    logger.debug(
-                        "All filtered tool names: %s",
-                        filtered_tool_names,
-                    )
-
-                    # Filter to only include tools that belong to this endpoint
-                    endpoint_tools = [
-                        tool_name
-                        for tool_name in filtered_tool_names
-                        if tool_to_endpoint.get(tool_name) == mcp_endpoint
-                    ]
-
-                    logger.debug(
-                        "MCP server %s (%s): Setting allowed_tools = %s (filtered from %d total tools)",  # pylint: disable=line-too-long
-                        server_label,
-                        mcp_endpoint,
-                        endpoint_tools,
-                        len(filtered_tool_names),
-                    )
-
-                    if endpoint_tools:
-                        if isinstance(tool, dict):
-                            tool["allowed_tools"] = endpoint_tools
-                        else:
-                            tool.allowed_tools = endpoint_tools
-                        result.append(tool)
-                    else:
-                        logger.warning(
-                            "MCP server %s (%s) has no matching tools - skipping from result",
-                            server_label,
-                            mcp_endpoint,
-                        )
-                else:
-                    # Non-MCP tools (file_search, function) are always included
-                    logger.debug(
-                        "Including non-MCP tool: type=%s, config=%s",
-                        tool_type,
-                        tool_dict.get("name") if tool_type == "function" else tool_type,
-                    )
-                    result.append(tool)
-
-            logger.info(
-                "Filtered tools: %d removed, %d remaining",
-                len(tools_for_filtering) - len(filtered_tool_names),
-                len(filtered_tool_names),
-            )
-            return result
-        logger.warning("No tools matched filtering criteria, returning empty list")
-        return []
+        result = self._build_filtered_tool_list(tools, filtered_tool_names, tool_to_endpoint)
+        logger.info(
+            "Filtered tools: %d removed, %d remaining",
+            len(tools_for_filtering) - len(filtered_tool_names),
+            len(filtered_tool_names),
+        )
+        return result
 
     async def _get_previously_called_tools(self, conversation_id: str) -> set[str]:
         """

--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
@@ -148,7 +148,8 @@ class LightspeedAgentsImpl(MetaReferenceAgentsImpl):
         Flatten the polymorphic input arg into a plain string for the LLM prompt.
 
         Parameters:
-            input: The raw user input, either a plain string or a list of OpenAIResponseInput messages.
+            input: The raw user input, either a plain string or a list of
+                OpenAIResponseInput messages.
 
         Returns:
             A single concatenated string suitable for passing to the LLM.
@@ -168,10 +169,12 @@ class LightspeedAgentsImpl(MetaReferenceAgentsImpl):
         Extract the JSON tool-name list from a freeform LLM response string.
 
         Parameters:
-            content: The raw string returned by the LLM, expected to contain a JSON array of tool names.
+            content: The raw string returned by the LLM, expected to
+                contain a JSON array of tool names.
 
         Returns:
-            A list of tool name strings parsed from the response, or an empty list if no valid JSON array is found.
+            A list of tool name strings parsed from the response, or an
+                empty list if no valid JSON array is found.
 
         """
         if "[" not in content or "]" not in content:
@@ -196,7 +199,8 @@ class LightspeedAgentsImpl(MetaReferenceAgentsImpl):
 
         Parameters:
             tools: The full list of tools available for the response.
-            filtered_tool_names: Tool names selected by the LLM to restrict MCP server access.
+            filtered_tool_names: Tool names selected by the LLM to restrict
+                MCP server access.
             tool_to_endpoint: Mapping of tool name to MCP server endpoint URL.
 
         Returns:
@@ -372,7 +376,9 @@ class LightspeedAgentsImpl(MetaReferenceAgentsImpl):
             logger.warning("No tools matched filtering criteria, returning empty list")
             return []
 
-        result = self._build_filtered_tool_list(tools, filtered_tool_names, tool_to_endpoint)
+        result = self._build_filtered_tool_list(
+            tools, filtered_tool_names, tool_to_endpoint
+        )
         logger.info(
             "Filtered tools: %d removed, %d remaining",
             len(tools_for_filtering) - len(filtered_tool_names),

--- a/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
+++ b/lightspeed_stack_providers/providers/inline/agents/lightspeed_inline_agent/agents.py
@@ -144,7 +144,16 @@ class LightspeedAgentsImpl(MetaReferenceAgentsImpl):
         return await super().create_openai_response(modified_request)
 
     def _extract_user_prompt(self, input: str | list[OpenAIResponseInput]) -> str:
-        """Flatten the polymorphic input arg into a plain string for the LLM prompt."""
+        """
+        Flatten the polymorphic input arg into a plain string for the LLM prompt.
+
+        Parameters:
+            input: The raw user input, either a plain string or a list of OpenAIResponseInput messages.
+
+        Returns:
+            A single concatenated string suitable for passing to the LLM.
+
+        """
         if isinstance(input, str):
             return input
         if isinstance(input, list):
@@ -155,7 +164,16 @@ class LightspeedAgentsImpl(MetaReferenceAgentsImpl):
         return str(input)
 
     def _parse_llm_tool_names(self, content: str) -> list[str]:
-        """Extract the JSON tool-name list from a freeform LLM response string."""
+        """
+        Extract the JSON tool-name list from a freeform LLM response string.
+
+        Parameters:
+            content: The raw string returned by the LLM, expected to contain a JSON array of tool names.
+
+        Returns:
+            A list of tool name strings parsed from the response, or an empty list if no valid JSON array is found.
+
+        """
         if "[" not in content or "]" not in content:
             return []
         list_str = content[content.rfind("[") : content.rfind("]") + 1]
@@ -173,7 +191,18 @@ class LightspeedAgentsImpl(MetaReferenceAgentsImpl):
         filtered_tool_names: list[str],
         tool_to_endpoint: dict[str, str],
     ) -> list[OpenAIResponseInputTool]:
-        """Walk tools and set allowed_tools on MCP entries; pass non-MCP tools through."""
+        """
+        Walk tools and set allowed_tools on MCP entries; pass non-MCP tools through.
+
+        Parameters:
+            tools: The full list of tools available for the response.
+            filtered_tool_names: Tool names selected by the LLM to restrict MCP server access.
+            tool_to_endpoint: Mapping of tool name to MCP server endpoint URL.
+
+        Returns:
+            A filtered tool list with allowed_tools populated on each MCP entry.
+
+        """
         result = []
         for tool in tools:
             tool_dict = tool if isinstance(tool, dict) else tool.model_dump()
@@ -194,7 +223,8 @@ class LightspeedAgentsImpl(MetaReferenceAgentsImpl):
                     if tool_to_endpoint.get(tool_name) == mcp_endpoint
                 ]
                 logger.debug(
-                    "MCP server %s (%s): Setting allowed_tools = %s (filtered from %d total tools)",
+                    "MCP server %s (%s): Setting allowed_tools = %s"
+                    "(filtered from %d total tools)",
                     server_label,
                     mcp_endpoint,
                     endpoint_tools,

--- a/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/solr.py
+++ b/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/solr.py
@@ -350,7 +350,8 @@ class SolrIndex(EmbeddingIndex):
             try:
                 log.info("Sending keyword query to Solr")
                 response = await client.get(
-                    f"{self.base_url}/select", params=solr_params  # type: ignore
+                    f"{self.base_url}/select",
+                    params=solr_params,  # type: ignore
                 )
                 response.raise_for_status()
                 data = response.json()
@@ -734,10 +735,11 @@ class SolrIndex(EmbeddingIndex):
             schema: ChunkWindowConfig defining family fields and token budgets.
 
         Returns:
-            A tuple of (boundary_values, token_budget, is_orphan): boundary_values is a dict
-            of family field values used to scope sibling queries (None if no family fields are
-            configured), token_budget is the applicable token ceiling, and is_orphan indicates
-            whether the chunk is missing all configured family field values.
+            A tuple of (boundary_values, token_budget, is_orphan): boundary_values
+                is a dict of family field values used to scope sibling queries
+                (None if no family fields are configured), token_budget is the
+                applicable token ceiling, and is_orphan indicates whether the
+                chunk is missing all configured family field values.
 
         """
         if not schema.chunk_family_fields:
@@ -758,7 +760,9 @@ class SolrIndex(EmbeddingIndex):
                 f"Chunk at index {chunk.metadata.get(schema.chunk_index_field)} is an orphan "
                 f"(missing family field values), using orphan_token_budget"
             )
-        token_budget = schema.orphan_token_budget if is_orphan else schema.family_token_budget
+        token_budget = (
+            schema.orphan_token_budget if is_orphan else schema.family_token_budget
+        )
         return boundary_values, token_budget, is_orphan
 
     async def _select_context_chunks_in_window(
@@ -788,13 +792,18 @@ class SolrIndex(EmbeddingIndex):
             token_budget: Maximum tokens allowed for the context window.
             boundary_values: Family field values used to filter sibling chunks, or None.
             schema: ChunkWindowConfig governing field names and expansion behavior.
-            min_chunk_window: Minimum chunk count below which the full document is returned.
+            min_chunk_window: Minimum chunk count below which the full
+                document is returned.
 
         Returns:
-            The selected list of Solr chunk dicts, or None if the caller should fall back to the original chunk.
+            The selected list of Solr chunk dicts, or None if the caller
+                should fall back to the original chunk.
 
         """
-        if total_chunks < min_chunk_window or total_tokens <= schema.family_token_budget:
+        if (
+            total_chunks < min_chunk_window
+            or total_tokens <= schema.family_token_budget
+        ):
             log.info(
                 f"Document is short (total_chunks={total_chunks}, "
                 f"total_tokens={total_tokens}), fetching all chunks"
@@ -859,14 +868,18 @@ class SolrIndex(EmbeddingIndex):
         Build the final EmbeddedChunk from the selected context window.
 
         Parameters:
-            chunk: The original matched EmbeddedChunk whose metadata is used as the base.
-            selected_chunks: Ordered list of Solr chunk dicts forming the context window.
-            parent_doc: The parent Solr document dict used to populate content ID metadata.
+            chunk: The original matched EmbeddedChunk whose metadata is used
+                as the base.
+            selected_chunks: Ordered list of Solr chunk dicts forming the
+                context window.
+            parent_doc: The parent Solr document dict used to populate content
+                ID metadata.
             schema: ChunkWindowConfig governing field names used during assembly.
             matched_chunk_index: The index of the matched chunk within the document.
 
         Returns:
-            A new EmbeddedChunk with concatenated content from the window and expanded metadata.
+            A new EmbeddedChunk with concatenated content from the window and
+                expanded metadata.
 
         """
         content_parts = [
@@ -1121,12 +1134,17 @@ class SolrIndex(EmbeddingIndex):
         if not self.chunk_window_config:
             return
         schema = self.chunk_window_config
-        if schema.chunk_online_source_url_field and schema.chunk_online_source_url_field in doc:
+        if (
+            schema.chunk_online_source_url_field
+            and schema.chunk_online_source_url_field in doc
+        ):
             metadata["reference_url"] = doc[schema.chunk_online_source_url_field]
         if schema.chunk_source_path_field and schema.chunk_source_path_field in doc:
             metadata["source_path"] = doc[schema.chunk_source_path_field]
         if schema.chunk_token_count_field in doc:
-            metadata[schema.chunk_token_count_field] = doc[schema.chunk_token_count_field]
+            metadata[schema.chunk_token_count_field] = doc[
+                schema.chunk_token_count_field
+            ]
         # Family fields are needed later for cross-chunk comparison
         for field in schema.chunk_family_fields or []:
             if field in doc:
@@ -1147,7 +1165,8 @@ class SolrIndex(EmbeddingIndex):
             parent_id: The parent document identifier, or None if unavailable.
 
         Returns:
-            A metadata dict populated with standard document fields and any configured window metadata.
+            A metadata dict populated with standard document fields and any
+                configured window metadata.
 
         """
         metadata: dict[str, Any] = {

--- a/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/solr.py
+++ b/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/solr.py
@@ -721,6 +721,148 @@ class SolrIndex(EmbeddingIndex):
             log.error(f"Error fetching context chunks for {parent_id}: {e}")
             return []
 
+    def _get_chunk_boundary_and_budget(
+        self,
+        chunk: EmbeddedChunk,
+        schema: ChunkWindowConfig,
+    ) -> tuple[Optional[dict[str, Any]], int, bool]:
+        """Return (boundary_values, token_budget, is_orphan) for a chunk."""
+        if not schema.chunk_family_fields:
+            return None, schema.family_token_budget, False
+
+        boundary_values: dict[str, Any] = {}
+        for field in schema.chunk_family_fields:
+            value = chunk.metadata.get(field)
+            if value is not None:
+                boundary_values[field] = value
+
+        # Orphan: chunk is missing values for ALL configured family fields
+        is_orphan = all(
+            chunk.metadata.get(field) is None for field in schema.chunk_family_fields
+        )
+        if is_orphan:
+            log.debug(
+                f"Chunk at index {chunk.metadata.get(schema.chunk_index_field)} is an orphan "
+                f"(missing family field values), using orphan_token_budget"
+            )
+        token_budget = schema.orphan_token_budget if is_orphan else schema.family_token_budget
+        return boundary_values, token_budget, is_orphan
+
+    async def _select_context_chunks_in_window(
+        self,
+        client: httpx.AsyncClient,
+        parent_id: str,
+        matched_chunk_index: int,
+        total_chunks: int,
+        total_tokens: int,
+        token_budget: int,
+        boundary_values: Optional[dict[str, Any]],
+        schema: ChunkWindowConfig,
+        min_chunk_window: int,
+    ) -> Optional[list[dict[str, Any]]]:
+        """
+        Select context chunks for a matched chunk.
+
+        Returns the selected chunk list, or None when the caller should fall back
+        to the original chunk (empty fetch or match position not found).
+        """
+        if total_chunks < min_chunk_window or total_tokens <= schema.family_token_budget:
+            log.info(
+                f"Document is short (total_chunks={total_chunks}, "
+                f"total_tokens={total_tokens}), fetching all chunks"
+            )
+            return await self._fetch_context_chunks(
+                client, parent_id, 0, max(0, total_chunks - 1)
+            )
+
+        window_start = max(0, matched_chunk_index - 10)
+        window_end = (
+            min(total_chunks - 1, matched_chunk_index + 10) if total_chunks > 0 else 0
+        )
+        log.info(
+            f"Document exceeds token budget (total_chunks={total_chunks}, "
+            f"total_tokens={total_tokens}, token_budget={token_budget}), "
+            f"fetching bounded window: [{window_start}, {window_end}] "
+            f"around match at index {matched_chunk_index}"
+        )
+        context_chunks = await self._fetch_context_chunks(
+            client, parent_id, window_start, window_end, boundary_values=boundary_values
+        )
+
+        if not context_chunks:
+            log.warning("No context chunks fetched, using original chunk")
+            return None
+
+        window_tokens = sum(
+            c.get(schema.chunk_token_count_field, 0) for c in context_chunks
+        )
+        if window_tokens <= token_budget:
+            log.info(
+                f"All {len(context_chunks)} context chunks fit in "
+                f"token budget ({window_tokens}/{token_budget}), skipping expansion loop"
+            )
+            return context_chunks
+
+        match_pos = next(
+            (
+                i
+                for i, c in enumerate(context_chunks)
+                if c.get(schema.chunk_index_field) == matched_chunk_index
+            ),
+            None,
+        )
+        if match_pos is None:
+            log.warning(
+                "Matched chunk not found in context window, using original chunk"
+            )
+            return None
+
+        return self._expand_chunk_window(context_chunks, match_pos, token_budget)
+
+    def _assemble_expanded_chunk(
+        self,
+        chunk: EmbeddedChunk,
+        selected_chunks: list[dict[str, Any]],
+        parent_doc: dict[str, Any],
+        schema: ChunkWindowConfig,
+        matched_chunk_index: int,
+    ) -> EmbeddedChunk:
+        """Build the final EmbeddedChunk from the selected context window."""
+        content_parts = [
+            c.get(self.content_field, "")
+            for c in selected_chunks
+            if c.get(self.content_field)
+        ]
+        final_content = "\n\n".join(content_parts)
+
+        expanded_metadata = dict(chunk.metadata) if chunk.metadata else {}
+        expanded_metadata["chunk_window_expanded"] = True
+        expanded_metadata["chunk_window_size"] = len(selected_chunks)
+        expanded_metadata["matched_chunk_index"] = matched_chunk_index
+
+        if schema.parent_content_id_field:
+            doc_id = parent_doc.get(schema.parent_content_id_field)
+            if doc_id:
+                expanded_metadata["doc_id"] = doc_id
+
+        if schema.parent_content_title_field:
+            title = parent_doc.get(schema.parent_content_title_field)
+            if title:
+                expanded_metadata["title"] = title
+
+        expanded_metadata["source"] = OKP_SOURCE
+
+        return EmbeddedChunk(
+            chunk_id=chunk.chunk_id,
+            content=final_content,
+            metadata=expanded_metadata,
+            chunk_metadata=expanded_metadata,
+            embedding=[],
+            embedding_model=self.embedding_model,
+            embedding_dimension=self.dimension,
+            metadata_token_count=None,
+        )
+
     async def _apply_chunk_window_expansion(
         self,
         initial_response: QueryChunksResponse,
@@ -762,7 +904,6 @@ class SolrIndex(EmbeddingIndex):
 
         async with self._create_http_client() as client:
             for chunk, score in zip(initial_response.chunks, initial_response.scores):
-                # Extract parent_id and chunk_index from metadata
                 if not chunk.metadata:
                     log.warning(
                         "Chunk missing metadata, skipping chunk window expansion"
@@ -794,179 +935,50 @@ class SolrIndex(EmbeddingIndex):
                     )
                     continue
 
-                # Keep this anchor
                 kept_indices_by_parent[parent_id].append(matched_chunk_index)
 
-                # Fetch parent metadata
                 parent_doc = await self._fetch_parent_metadata(client, parent_id)
                 if not parent_doc:
-                    log.warning(f"Parent document not found for {
-                            parent_id
-                        }, using original chunk")
+                    log.warning(
+                        f"Parent document not found for {parent_id}, using original chunk"
+                    )
                     expanded_chunks.append(chunk)
                     expanded_scores.append(score)
                     continue
 
                 total_chunks = parent_doc.get(schema.parent_total_chunks_field, 0)
                 total_tokens = parent_doc.get(schema.parent_total_tokens_field, 0)
-
-                # Build boundary values from matched chunk metadata and
-                # determine whether this chunk is an orphan (missing family fields)
-                boundary_values = None
-                is_orphan = False
-                if schema.chunk_family_fields:
-                    boundary_values = {}
-                    for field in schema.chunk_family_fields:
-                        value = chunk.metadata.get(field)
-                        if value is not None:
-                            boundary_values[field] = value
-
-                    # mark the chunk as an orphan if it is missing values for
-                    # ALL the family fields.
-                    is_orphan = all(
-                        chunk.metadata.get(field) is None
-                        for field in schema.chunk_family_fields
-                    )
-                    if is_orphan:
-                        log.debug(
-                            f"Chunk at index {matched_chunk_index} is an orphan "
-                            f"(missing family field values), using orphan_token_budget"
-                        )
-
-                token_budget = (
-                    schema.orphan_token_budget
-                    if is_orphan
-                    else schema.family_token_budget
+                boundary_values, token_budget, _ = self._get_chunk_boundary_and_budget(
+                    chunk, schema
                 )
 
-                # If short doc, return all chunks
-                if (
-                    total_chunks < min_chunk_window
-                    or total_tokens <= schema.family_token_budget
-                ):
-                    log.info(
-                        f"Document is short (total_chunks={total_chunks}, "
-                        f"total_tokens={total_tokens}), fetching all chunks"
-                    )
-                    context_chunks = await self._fetch_context_chunks(
-                        client, parent_id, 0, max(0, total_chunks - 1)
-                    )
-                    selected_chunks = context_chunks
-                else:
-                    log.info(
-                        f"Document exceeds token budget (total_chunks={total_chunks}, "
-                        f"total_tokens={total_tokens}, "
-                        f"{'orphan' if is_orphan else 'family'}_token_budget={token_budget}), "
-                        f"expanding window around match"
-                    )
-
-                    # Fetch bounded window around match (±10 chunks)
-                    window_start = max(0, matched_chunk_index - 10)
-                    window_end = (
-                        min(total_chunks - 1, matched_chunk_index + 10)
-                        if total_chunks > 0
-                        else 0
-                    )
-
-                    log.info(
-                        f"Fetching bounded window: [{window_start}, {window_end}] "
-                        f"around match at index {matched_chunk_index}"
-                    )
-                    context_chunks = await self._fetch_context_chunks(
-                        client,
-                        parent_id,
-                        window_start,
-                        window_end,
-                        boundary_values=boundary_values,
-                    )
-
-                    if not context_chunks:
-                        log.warning("No context chunks fetched, using original chunk")
-                        expanded_chunks.append(chunk)
-                        expanded_scores.append(score)
-                        continue
-
-                    # If all fetched chunks fit in the token budget, use them
-                    # all directly (no need to run expansion loop)
-                    window_tokens = sum(
-                        c.get(schema.chunk_token_count_field, 0) for c in context_chunks
-                    )
-                    if window_tokens <= token_budget:
-                        log.info(
-                            f"All {len(context_chunks)} context chunks fit in "
-                            f"token budget ({window_tokens}/{token_budget}), "
-                            f"skipping expansion loop"
-                        )
-                        selected_chunks = context_chunks
-                    else:
-                        # Find local match index in the fetched window
-                        match_pos = None
-                        for i, c in enumerate(context_chunks):
-                            if c.get(schema.chunk_index_field) == matched_chunk_index:
-                                match_pos = i
-                                break
-
-                        if match_pos is None:
-                            log.warning(
-                                "Matched chunk not found in context window, "
-                                "using original chunk"
-                            )
-                            expanded_chunks.append(chunk)
-                            expanded_scores.append(score)
-                            continue
-
-                        # Apply token budget expansion
-                        selected_chunks = self._expand_chunk_window(
-                            context_chunks, match_pos, token_budget
-                        )
-
-                # Concatenate selected chunks into final content
-                content_parts = []
-                for selected_chunk in selected_chunks:
-                    content = selected_chunk.get(self.content_field, "")
-                    if content:
-                        content_parts.append(content)
-
-                final_content = "\n\n".join(content_parts)
-
-                # Build expanded chunk metadata
-                expanded_metadata = dict(chunk.metadata) if chunk.metadata else {}
-                expanded_metadata["chunk_window_expanded"] = True
-                expanded_metadata["chunk_window_size"] = len(selected_chunks)
-                expanded_metadata["matched_chunk_index"] = matched_chunk_index
-
-                # Add optional parent metadata if available
-                if schema.parent_content_id_field:
-                    doc_id = parent_doc.get(schema.parent_content_id_field)
-                    if doc_id:
-                        expanded_metadata["doc_id"] = doc_id
-
-                if schema.parent_content_title_field:
-                    title = parent_doc.get(schema.parent_content_title_field)
-                    if title:
-                        expanded_metadata["title"] = title
-
-                expanded_metadata["source"] = OKP_SOURCE
-
-                # Create expanded chunk
-                expanded_chunk = EmbeddedChunk(
-                    chunk_id=chunk.chunk_id,
-                    content=final_content,
-                    metadata=expanded_metadata,
-                    chunk_metadata=expanded_metadata,
-                    embedding=[],
-                    embedding_model=self.embedding_model,
-                    embedding_dimension=self.dimension,
-                    metadata_token_count=None,
+                selected_chunks = await self._select_context_chunks_in_window(
+                    client,
+                    parent_id,
+                    matched_chunk_index,
+                    total_chunks,
+                    total_tokens,
+                    token_budget,
+                    boundary_values,
+                    schema,
+                    min_chunk_window,
                 )
 
+                if selected_chunks is None:
+                    expanded_chunks.append(chunk)
+                    expanded_scores.append(score)
+                    continue
+
+                expanded_chunk = self._assemble_expanded_chunk(
+                    chunk, selected_chunks, parent_doc, schema, matched_chunk_index
+                )
                 expanded_chunks.append(expanded_chunk)
                 expanded_scores.append(score)
 
-        log.info(f"Chunk window expansion complete: {
-                len(initial_response.chunks)
-            } initial chunks -> " f"{len(expanded_chunks)} expanded chunks")
-
+        log.info(
+            f"Chunk window expansion complete: {len(initial_response.chunks)} "
+            f"initial chunks -> {len(expanded_chunks)} expanded chunks"
+        )
         return QueryChunksResponse(chunks=expanded_chunks, scores=expanded_scores)
 
     def _expand_chunk_window(
@@ -1054,6 +1066,43 @@ class SolrIndex(EmbeddingIndex):
         )
         return selected
 
+    def _add_window_config_metadata(
+        self, doc: dict[str, Any], metadata: dict[str, Any]
+    ) -> None:
+        """Populate metadata with fields sourced from chunk_window_config."""
+        if not self.chunk_window_config:
+            return
+        schema = self.chunk_window_config
+        if schema.chunk_online_source_url_field and schema.chunk_online_source_url_field in doc:
+            metadata["reference_url"] = doc[schema.chunk_online_source_url_field]
+        if schema.chunk_source_path_field and schema.chunk_source_path_field in doc:
+            metadata["source_path"] = doc[schema.chunk_source_path_field]
+        if schema.chunk_token_count_field in doc:
+            metadata[schema.chunk_token_count_field] = doc[schema.chunk_token_count_field]
+        # Family fields are needed later for cross-chunk comparison
+        for field in schema.chunk_family_fields or []:
+            if field in doc:
+                metadata[field] = doc[field]
+
+    def _build_doc_metadata(
+        self,
+        doc: dict[str, Any],
+        chunk_id: Any,
+        parent_id: Optional[str],
+    ) -> dict[str, Any]:
+        """Build the full metadata dict for a Solr document."""
+        metadata: dict[str, Any] = {
+            "document_id": parent_id,
+            "doc_id": parent_id,
+            "chunk_id": chunk_id,
+            "source": OKP_SOURCE,
+        }
+        for field in ("title", "resourceName", "chunk_index", "parent_id"):
+            if field in doc:
+                metadata[field] = doc[field]
+        self._add_window_config_metadata(doc, metadata)
+        return metadata
+
     def _doc_to_chunk(self, doc: dict[str, Any]) -> Optional[Chunk]:
         """
         Convert a Solr document dictionary into an EmbeddedChunk suitable for search responses.
@@ -1099,58 +1148,13 @@ class SolrIndex(EmbeddingIndex):
                 )
             )
 
-            metadata: dict[str, Any] = {
-                "document_id": parent_id,
-                "doc_id": parent_id,
-                "chunk_id": chunk_id,
-                "source": OKP_SOURCE,
-            }
-
-            # helpful extras if present
-            if "title" in doc:
-                metadata["title"] = doc["title"]
-            if (
-                self.chunk_window_config
-                and self.chunk_window_config.chunk_online_source_url_field
-            ):
-                url_field = self.chunk_window_config.chunk_online_source_url_field
-                if url_field in doc:
-                    metadata["reference_url"] = doc[url_field]
-            if (
-                self.chunk_window_config
-                and self.chunk_window_config.chunk_source_path_field
-            ):
-                path_field = self.chunk_window_config.chunk_source_path_field
-                if path_field in doc:
-                    metadata["source_path"] = doc[path_field]
-            if "resourceName" in doc:
-                metadata["resourceName"] = doc["resourceName"]
-            if "chunk_index" in doc:
-                metadata["chunk_index"] = doc["chunk_index"]
-            if "parent_id" in doc:
-                metadata["parent_id"] = doc["parent_id"]
-            if (
-                self.chunk_window_config is not None
-                and self.chunk_window_config.chunk_token_count_field in doc
-            ):
-                metadata[self.chunk_window_config.chunk_token_count_field] = doc[
-                    self.chunk_window_config.chunk_token_count_field
-                ]
-            # add family fields to the metadata since we need to access them
-            # for comparison with other chunks later on
-            if (
-                self.chunk_window_config is not None
-                and self.chunk_window_config.chunk_family_fields
-            ):
-                for field in self.chunk_window_config.chunk_family_fields:
-                    if field in doc:
-                        metadata[field] = doc[field]
+            metadata = self._build_doc_metadata(doc, chunk_id, parent_id)
 
             embedding = doc.get(self.vector_field)
-            if isinstance(embedding, list):
-                embedding = [float(x) for x in embedding]
-            else:
+            if not isinstance(embedding, list):
                 embedding = []
+            else:
+                embedding = [float(x) for x in embedding]
 
             return EmbeddedChunk(
                 chunk_id=str(chunk_id),

--- a/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/solr.py
+++ b/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/solr.py
@@ -726,7 +726,20 @@ class SolrIndex(EmbeddingIndex):
         chunk: EmbeddedChunk,
         schema: ChunkWindowConfig,
     ) -> tuple[Optional[dict[str, Any]], int, bool]:
-        """Return (boundary_values, token_budget, is_orphan) for a chunk."""
+        """
+        Return (boundary_values, token_budget, is_orphan) for a chunk.
+
+        Parameters:
+            chunk: The matched EmbeddedChunk to evaluate.
+            schema: ChunkWindowConfig defining family fields and token budgets.
+
+        Returns:
+            A tuple of (boundary_values, token_budget, is_orphan): boundary_values is a dict
+            of family field values used to scope sibling queries (None if no family fields are
+            configured), token_budget is the applicable token ceiling, and is_orphan indicates
+            whether the chunk is missing all configured family field values.
+
+        """
         if not schema.chunk_family_fields:
             return None, schema.family_token_budget, False
 
@@ -765,6 +778,21 @@ class SolrIndex(EmbeddingIndex):
 
         Returns the selected chunk list, or None when the caller should fall back
         to the original chunk (empty fetch or match position not found).
+
+        Parameters:
+            client: The async HTTP client for Solr requests.
+            parent_id: The parent document identifier used to scope the chunk query.
+            matched_chunk_index: The index of the matched chunk within the document.
+            total_chunks: Total number of chunks in the parent document.
+            total_tokens: Total token count across all chunks in the document.
+            token_budget: Maximum tokens allowed for the context window.
+            boundary_values: Family field values used to filter sibling chunks, or None.
+            schema: ChunkWindowConfig governing field names and expansion behavior.
+            min_chunk_window: Minimum chunk count below which the full document is returned.
+
+        Returns:
+            The selected list of Solr chunk dicts, or None if the caller should fall back to the original chunk.
+
         """
         if total_chunks < min_chunk_window or total_tokens <= schema.family_token_budget:
             log.info(
@@ -827,7 +855,20 @@ class SolrIndex(EmbeddingIndex):
         schema: ChunkWindowConfig,
         matched_chunk_index: int,
     ) -> EmbeddedChunk:
-        """Build the final EmbeddedChunk from the selected context window."""
+        """
+        Build the final EmbeddedChunk from the selected context window.
+
+        Parameters:
+            chunk: The original matched EmbeddedChunk whose metadata is used as the base.
+            selected_chunks: Ordered list of Solr chunk dicts forming the context window.
+            parent_doc: The parent Solr document dict used to populate content ID metadata.
+            schema: ChunkWindowConfig governing field names used during assembly.
+            matched_chunk_index: The index of the matched chunk within the document.
+
+        Returns:
+            A new EmbeddedChunk with concatenated content from the window and expanded metadata.
+
+        """
         content_parts = [
             c.get(self.content_field, "")
             for c in selected_chunks
@@ -1069,7 +1110,14 @@ class SolrIndex(EmbeddingIndex):
     def _add_window_config_metadata(
         self, doc: dict[str, Any], metadata: dict[str, Any]
     ) -> None:
-        """Populate metadata with fields sourced from chunk_window_config."""
+        """
+        Populate metadata with fields sourced from chunk_window_config.
+
+        Parameters:
+            doc: The Solr document dict to read field values from.
+            metadata: The metadata dict to populate in place.
+
+        """
         if not self.chunk_window_config:
             return
         schema = self.chunk_window_config
@@ -1090,7 +1138,18 @@ class SolrIndex(EmbeddingIndex):
         chunk_id: Any,
         parent_id: Optional[str],
     ) -> dict[str, Any]:
-        """Build the full metadata dict for a Solr document."""
+        """
+        Build the full metadata dict for a Solr document.
+
+        Parameters:
+            doc: The Solr document dict to read field values from.
+            chunk_id: The chunk identifier value.
+            parent_id: The parent document identifier, or None if unavailable.
+
+        Returns:
+            A metadata dict populated with standard document fields and any configured window metadata.
+
+        """
         metadata: dict[str, Any] = {
             "document_id": parent_id,
             "doc_id": parent_id,

--- a/tests/unit/providers/inline/agents/lightspeed_inline_agent/test_agent_instance_inline_agent.py
+++ b/tests/unit/providers/inline/agents/lightspeed_inline_agent/test_agent_instance_inline_agent.py
@@ -522,5 +522,3 @@ def test_parse_llm_tool_names_uses_last_bracket_pair(
     """Test that when the response contains multiple bracket pairs, the last one is used."""
     content = 'ignore [this] use ["tool1"]'
     assert lightspeed_agents_impl._parse_llm_tool_names(content) == ["tool1"]
-
-

--- a/tests/unit/providers/inline/agents/lightspeed_inline_agent/test_agent_instance_inline_agent.py
+++ b/tests/unit/providers/inline/agents/lightspeed_inline_agent/test_agent_instance_inline_agent.py
@@ -455,3 +455,72 @@ async def test_filter_tools_preserves_previously_called_tools(
     assert filtered_tools[0]["type"] == "mcp"
     assert filtered_tools[0]["server_url"] == "http://test1.com"
     assert "previously_used_tool" in filtered_tools[0]["allowed_tools"]
+
+
+def test_extract_user_prompt_string_passthrough(
+    lightspeed_agents_impl: LightspeedAgentsImpl,
+) -> None:
+    """Test that a plain string input is returned unchanged."""
+    assert lightspeed_agents_impl._extract_user_prompt("hello world") == "hello world"
+
+
+def test_extract_user_prompt_list_of_dicts_joined_on_newline(
+    lightspeed_agents_impl: LightspeedAgentsImpl,
+) -> None:
+    """Test that a list of message dicts has content values joined with newlines."""
+    msgs = [{"content": "foo"}, {"content": "bar"}]
+    assert lightspeed_agents_impl._extract_user_prompt(msgs) == "foo\nbar"
+
+
+def test_extract_user_prompt_dict_missing_content_key_uses_empty_string(
+    lightspeed_agents_impl: LightspeedAgentsImpl,
+) -> None:
+    """Test that a message dict without a content key contributes an empty string."""
+    msgs = [{"content": "foo"}, {"role": "user"}]
+    assert lightspeed_agents_impl._extract_user_prompt(msgs) == "foo\n"
+
+
+def test_extract_user_prompt_list_of_non_dicts_uses_str(
+    lightspeed_agents_impl: LightspeedAgentsImpl,
+) -> None:
+    """Test that non-dict list items are converted with str()."""
+    assert lightspeed_agents_impl._extract_user_prompt(["a", "b"]) == "a\nb"
+
+
+def test_parse_llm_tool_names_extracts_valid_json_list(
+    lightspeed_agents_impl: LightspeedAgentsImpl,
+) -> None:
+    """Test that a valid JSON list embedded in the response text is extracted correctly."""
+    content = 'Here are the results: ["tool1", "tool2"]'
+    assert lightspeed_agents_impl._parse_llm_tool_names(content) == ["tool1", "tool2"]
+
+
+def test_parse_llm_tool_names_empty_json_list(
+    lightspeed_agents_impl: LightspeedAgentsImpl,
+) -> None:
+    """Test that an empty JSON list in the response returns an empty list."""
+    assert lightspeed_agents_impl._parse_llm_tool_names("No tools found: []") == []
+
+
+def test_parse_llm_tool_names_no_brackets_returns_empty(
+    lightspeed_agents_impl: LightspeedAgentsImpl,
+) -> None:
+    """Test that a response with no brackets returns an empty list."""
+    assert lightspeed_agents_impl._parse_llm_tool_names("no brackets here") == []
+
+
+def test_parse_llm_tool_names_invalid_json_returns_empty(
+    lightspeed_agents_impl: LightspeedAgentsImpl,
+) -> None:
+    """Test that a malformed JSON fragment between brackets returns an empty list."""
+    assert lightspeed_agents_impl._parse_llm_tool_names("[not valid json}") == []
+
+
+def test_parse_llm_tool_names_uses_last_bracket_pair(
+    lightspeed_agents_impl: LightspeedAgentsImpl,
+) -> None:
+    """Test that when the response contains multiple bracket pairs, the last one is used."""
+    content = 'ignore [this] use ["tool1"]'
+    assert lightspeed_agents_impl._parse_llm_tool_names(content) == ["tool1"]
+
+

--- a/tests/unit/providers/remote/solr_vector_io/test_doc_to_chunk.py
+++ b/tests/unit/providers/remote/solr_vector_io/test_doc_to_chunk.py
@@ -178,5 +178,3 @@ class TestGuardClauses:
     def test_missing_chunk_id_returns_none(self, solr_index):
         chunk = solr_index._doc_to_chunk({"chunk": "Content."})
         assert chunk is None
-
-

--- a/tests/unit/providers/remote/solr_vector_io/test_doc_to_chunk.py
+++ b/tests/unit/providers/remote/solr_vector_io/test_doc_to_chunk.py
@@ -178,3 +178,5 @@ class TestGuardClauses:
     def test_missing_chunk_id_returns_none(self, solr_index):
         chunk = solr_index._doc_to_chunk({"chunk": "Content."})
         assert chunk is None
+
+

--- a/tests/unit/providers/remote/solr_vector_io/test_solr_chunk_window.py
+++ b/tests/unit/providers/remote/solr_vector_io/test_solr_chunk_window.py
@@ -1,0 +1,380 @@
+"""
+Unit tests for the private helper methods extracted from _apply_chunk_window_expansion.
+
+Covers _get_chunk_boundary_and_budget, _assemble_expanded_chunk, and
+_select_context_chunks_in_window without requiring a running Solr instance.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from llama_stack_api.vector_io import EmbeddedChunk
+from llama_stack_api.vector_stores import VectorStore as VectorDB
+from pytest_mock import MockerFixture
+
+from lightspeed_stack_providers.providers.remote.solr_vector_io.solr_vector_io.src.solr_vector_io.config import (
+    ChunkWindowConfig,
+)
+from lightspeed_stack_providers.providers.remote.solr_vector_io.solr_vector_io.src.solr_vector_io.solr import (
+    OKP_SOURCE,
+    SolrIndex,
+)
+
+EMBEDDING_DIM = 384
+EMBEDDING_MODEL = "ibm-granite/granite-embedding-30m-english"
+
+
+@pytest.fixture
+def chunk_window_config() -> ChunkWindowConfig:
+    """
+    Create a ChunkWindowConfig with all optional fields populated.
+
+    Returns:
+        ChunkWindowConfig: Configuration used across chunk window expansion tests.
+    """
+    return ChunkWindowConfig(
+        chunk_parent_id_field="parent_id",
+        chunk_index_field="chunk_index",
+        chunk_content_field="chunk",
+        chunk_token_count_field="num_tokens",
+        chunk_online_source_url_field="online_source_url",
+        chunk_source_path_field="source_path",
+        parent_total_chunks_field="total_chunks",
+        parent_total_tokens_field="total_tokens",
+        parent_content_id_field="doc_id",
+        parent_content_title_field="title",
+        family_token_budget=3072,
+        orphan_token_budget=1536,
+    )
+
+
+@pytest.fixture
+def chunk_window_config_with_family(chunk_window_config: ChunkWindowConfig) -> ChunkWindowConfig:
+    """
+    Return a ChunkWindowConfig with chunk_family_fields set to ['heading'].
+
+    Parameters:
+        chunk_window_config (ChunkWindowConfig): Base configuration to extend.
+
+    Returns:
+        ChunkWindowConfig: Configuration with heading as a family field.
+    """
+    return chunk_window_config.model_copy(update={"chunk_family_fields": ["heading"]})
+
+
+@pytest.fixture
+def solr_index(chunk_window_config: ChunkWindowConfig) -> SolrIndex:
+    """
+    Return a SolrIndex configured for tests without calling initialize().
+
+    Parameters:
+        chunk_window_config (ChunkWindowConfig): Configuration injected into the index.
+
+    Returns:
+        SolrIndex: Test instance with no Solr connection required.
+    """
+    vector_store = VectorDB(
+        identifier="test-store",
+        embedding_dimension=EMBEDDING_DIM,
+        embedding_model=EMBEDDING_MODEL,
+        provider_id="solr",
+    )
+    return SolrIndex(
+        vector_store=vector_store,
+        solr_url="http://localhost:8983/solr",
+        collection_name="test",
+        vector_field="chunk_vector",
+        content_field="chunk",
+        id_field="id",
+        dimension=EMBEDDING_DIM,
+        embedding_model=EMBEDDING_MODEL,
+        chunk_window_config=chunk_window_config,
+    )
+
+
+@pytest.fixture
+def solr_index_with_family(chunk_window_config_with_family: ChunkWindowConfig) -> SolrIndex:
+    """
+    Return a SolrIndex with chunk_family_fields=['heading'].
+
+    Parameters:
+        chunk_window_config_with_family (ChunkWindowConfig): Config with family fields set.
+
+    Returns:
+        SolrIndex: Test instance configured with family field support.
+    """
+    vector_store = VectorDB(
+        identifier="test-store",
+        embedding_dimension=EMBEDDING_DIM,
+        embedding_model=EMBEDDING_MODEL,
+        provider_id="solr",
+    )
+    return SolrIndex(
+        vector_store=vector_store,
+        solr_url="http://localhost:8983/solr",
+        collection_name="test",
+        vector_field="chunk_vector",
+        content_field="chunk",
+        id_field="id",
+        dimension=EMBEDDING_DIM,
+        embedding_model=EMBEDDING_MODEL,
+        chunk_window_config=chunk_window_config_with_family,
+    )
+
+
+def _make_chunk(metadata: dict) -> EmbeddedChunk:
+    """
+    Return a minimal EmbeddedChunk populated with the given metadata.
+
+    Parameters:
+        metadata (dict): Metadata dict to attach to the chunk.
+
+    Returns:
+        EmbeddedChunk: Test chunk with fixed chunk_id and content.
+    """
+    return EmbeddedChunk(
+        chunk_id="doc_chunk_0",
+        content="original content",
+        metadata=metadata,
+        chunk_metadata=metadata,
+        embedding=[],
+        embedding_model=EMBEDDING_MODEL,
+        embedding_dimension=EMBEDDING_DIM,
+        metadata_token_count=None,
+    )
+
+
+class TestGetChunkBoundaryAndBudget:
+    """Tests for _get_chunk_boundary_and_budget."""
+
+    def test_no_family_fields_returns_none_boundary_and_family_budget(
+        self, solr_index: SolrIndex
+    ) -> None:
+        """Test that without chunk_family_fields, boundary is None and family budget is used."""
+        chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 2})
+        boundary, budget, is_orphan = solr_index._get_chunk_boundary_and_budget(
+            chunk, solr_index.chunk_window_config
+        )
+        assert boundary is None
+        assert budget == 3072
+        assert is_orphan is False
+
+    def test_family_chunk_returns_boundary_values_and_family_budget(
+        self, solr_index_with_family: SolrIndex
+    ) -> None:
+        """Test that a chunk with a family field value gets its boundary dict and family budget."""
+        chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 2, "heading": "Intro"})
+        schema = solr_index_with_family.chunk_window_config
+        boundary, budget, is_orphan = solr_index_with_family._get_chunk_boundary_and_budget(
+            chunk, schema
+        )
+        assert boundary == {"heading": "Intro"}
+        assert budget == 3072
+        assert is_orphan is False
+
+    def test_orphan_chunk_uses_orphan_budget(
+        self, solr_index_with_family: SolrIndex
+    ) -> None:
+        """Test that a chunk missing all family field values is flagged as orphan and gets orphan budget."""
+        chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 5})
+        schema = solr_index_with_family.chunk_window_config
+        boundary, budget, is_orphan = solr_index_with_family._get_chunk_boundary_and_budget(
+            chunk, schema
+        )
+        assert boundary == {}
+        assert budget == 1536
+        assert is_orphan is True
+
+    def test_chunk_with_any_family_field_value_is_not_orphan(
+        self, solr_index_with_family: SolrIndex
+    ) -> None:
+        """Test that a chunk with at least one family field value is not treated as an orphan."""
+        chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 2, "heading": "Ch1"})
+        schema = solr_index_with_family.chunk_window_config
+        _, _, is_orphan = solr_index_with_family._get_chunk_boundary_and_budget(chunk, schema)
+        assert is_orphan is False
+
+
+class TestAssembleExpandedChunk:
+    """Tests for _assemble_expanded_chunk."""
+
+    def test_content_joined_with_double_newline(self, solr_index: SolrIndex) -> None:
+        """Test that selected chunk content is concatenated with double newlines."""
+        chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 1})
+        selected = [{"chunk": "First.", "num_tokens": 5}, {"chunk": "Second.", "num_tokens": 5}]
+        result = solr_index._assemble_expanded_chunk(
+            chunk, selected, {}, solr_index.chunk_window_config, matched_chunk_index=1
+        )
+        assert result.content == "First.\n\nSecond."
+
+    def test_empty_content_chunks_are_skipped(self, solr_index: SolrIndex) -> None:
+        """Test that chunks with an empty content field are excluded from the joined output."""
+        chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 0})
+        selected = [{"chunk": "", "num_tokens": 0}, {"chunk": "Only this.", "num_tokens": 5}]
+        result = solr_index._assemble_expanded_chunk(
+            chunk, selected, {}, solr_index.chunk_window_config, matched_chunk_index=0
+        )
+        assert result.content == "Only this."
+
+    def test_expansion_metadata_flags_set(self, solr_index: SolrIndex) -> None:
+        """Test that chunk_window_expanded, chunk_window_size, and matched_chunk_index are written."""
+        chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 2})
+        selected = [{"chunk": "a", "num_tokens": 5}, {"chunk": "b", "num_tokens": 5}]
+        result = solr_index._assemble_expanded_chunk(
+            chunk, selected, {}, solr_index.chunk_window_config, matched_chunk_index=2
+        )
+        assert result.metadata["chunk_window_expanded"] is True
+        assert result.metadata["chunk_window_size"] == 2
+        assert result.metadata["matched_chunk_index"] == 2
+
+    def test_parent_doc_id_written_to_metadata(self, solr_index: SolrIndex) -> None:
+        """Test that doc_id from the parent document is included when the field is configured."""
+        chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 0})
+        result = solr_index._assemble_expanded_chunk(
+            chunk, [{"chunk": "x", "num_tokens": 5}],
+            {"doc_id": "content-abc", "title": "My Doc"},
+            solr_index.chunk_window_config, matched_chunk_index=0,
+        )
+        assert result.metadata["doc_id"] == "content-abc"
+
+    def test_parent_title_written_to_metadata(self, solr_index: SolrIndex) -> None:
+        """Test that title from the parent document is included when the field is configured."""
+        chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 0})
+        result = solr_index._assemble_expanded_chunk(
+            chunk, [{"chunk": "x", "num_tokens": 5}],
+            {"doc_id": "content-abc", "title": "My Doc"},
+            solr_index.chunk_window_config, matched_chunk_index=0,
+        )
+        assert result.metadata["title"] == "My Doc"
+
+    def test_source_always_set_to_okp(self, solr_index: SolrIndex) -> None:
+        """Test that source is always set to OKP_SOURCE regardless of parent doc content."""
+        chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 0})
+        result = solr_index._assemble_expanded_chunk(
+            chunk, [{"chunk": "x", "num_tokens": 5}], {},
+            solr_index.chunk_window_config, matched_chunk_index=0,
+        )
+        assert result.metadata["source"] == OKP_SOURCE
+
+    def test_chunk_id_preserved_from_original(self, solr_index: SolrIndex) -> None:
+        """Test that chunk_id on the result matches the original chunk's chunk_id."""
+        chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 0})
+        result = solr_index._assemble_expanded_chunk(
+            chunk, [{"chunk": "x", "num_tokens": 5}], {},
+            solr_index.chunk_window_config, matched_chunk_index=0,
+        )
+        assert result.chunk_id == "doc_chunk_0"
+
+
+class TestSelectContextChunksInWindow:
+    """Tests for _select_context_chunks_in_window (HTTP calls mocked via mocker)."""
+
+    @pytest.mark.asyncio
+    async def test_short_doc_fetches_all_chunks(
+        self, solr_index: SolrIndex, mocker: MockerFixture
+    ) -> None:
+        """Test that total_chunks < min_chunk_window triggers a full fetch of all chunks."""
+        all_chunks = [{"chunk_index": i, "chunk": f"c{i}", "num_tokens": 10} for i in range(3)]
+        mocker.patch.object(
+            solr_index, "_fetch_context_chunks", AsyncMock(return_value=all_chunks)
+        )
+        result = await solr_index._select_context_chunks_in_window(
+            client=mocker.MagicMock(),
+            parent_id="doc1",
+            matched_chunk_index=1,
+            total_chunks=3,
+            total_tokens=30,
+            token_budget=3072,
+            boundary_values=None,
+            schema=solr_index.chunk_window_config,
+            min_chunk_window=4,
+        )
+        assert result == all_chunks
+
+    @pytest.mark.asyncio
+    async def test_window_fitting_budget_returned_directly(
+        self, solr_index: SolrIndex, mocker: MockerFixture
+    ) -> None:
+        """Test that context chunks fitting within the token budget are returned without expansion."""
+        window = [{"chunk_index": i, "chunk": f"c{i}", "num_tokens": 50} for i in range(5)]
+        mocker.patch.object(
+            solr_index, "_fetch_context_chunks", AsyncMock(return_value=window)
+        )
+        result = await solr_index._select_context_chunks_in_window(
+            client=mocker.MagicMock(),
+            parent_id="doc1",
+            matched_chunk_index=10,
+            total_chunks=100,
+            total_tokens=5000,
+            token_budget=3072,
+            boundary_values=None,
+            schema=solr_index.chunk_window_config,
+            min_chunk_window=4,
+        )
+        assert result == window
+
+    @pytest.mark.asyncio
+    async def test_over_budget_delegates_to_expand_chunk_window(
+        self, solr_index: SolrIndex, mocker: MockerFixture
+    ) -> None:
+        """Test that an over-budget window calls _expand_chunk_window and returns its result."""
+        big_window = [{"chunk_index": i, "chunk": f"c{i}", "num_tokens": 1000} for i in range(5)]
+        mocker.patch.object(
+            solr_index, "_fetch_context_chunks", AsyncMock(return_value=big_window)
+        )
+        mocker.patch.object(solr_index, "_expand_chunk_window", return_value=big_window[:2])
+        result = await solr_index._select_context_chunks_in_window(
+            client=mocker.MagicMock(),
+            parent_id="doc1",
+            matched_chunk_index=2,
+            total_chunks=100,
+            total_tokens=5000,
+            token_budget=3072,
+            boundary_values=None,
+            schema=solr_index.chunk_window_config,
+            min_chunk_window=4,
+        )
+        assert result == big_window[:2]
+
+    @pytest.mark.asyncio
+    async def test_empty_fetch_returns_none(
+        self, solr_index: SolrIndex, mocker: MockerFixture
+    ) -> None:
+        """Test that an empty context chunk fetch returns None to signal fallback to original chunk."""
+        mocker.patch.object(
+            solr_index, "_fetch_context_chunks", AsyncMock(return_value=[])
+        )
+        result = await solr_index._select_context_chunks_in_window(
+            client=mocker.MagicMock(),
+            parent_id="doc1",
+            matched_chunk_index=10,
+            total_chunks=100,
+            total_tokens=5000,
+            token_budget=3072,
+            boundary_values=None,
+            schema=solr_index.chunk_window_config,
+            min_chunk_window=4,
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_match_index_absent_from_window_returns_none(
+        self, solr_index: SolrIndex, mocker: MockerFixture
+    ) -> None:
+        """Test that a matched chunk absent from the fetched window returns None to signal fallback."""
+        chunks = [{"chunk_index": 99, "chunk": "x", "num_tokens": 1000}]
+        mocker.patch.object(
+            solr_index, "_fetch_context_chunks", AsyncMock(return_value=chunks)
+        )
+        result = await solr_index._select_context_chunks_in_window(
+            client=mocker.MagicMock(),
+            parent_id="doc1",
+            matched_chunk_index=2,
+            total_chunks=100,
+            total_tokens=5000,
+            token_budget=500,
+            boundary_values=None,
+            schema=solr_index.chunk_window_config,
+            min_chunk_window=4,
+        )
+        assert result is None

--- a/tests/unit/providers/remote/solr_vector_io/test_solr_chunk_window.py
+++ b/tests/unit/providers/remote/solr_vector_io/test_solr_chunk_window.py
@@ -49,7 +49,9 @@ def chunk_window_config() -> ChunkWindowConfig:
 
 
 @pytest.fixture
-def chunk_window_config_with_family(chunk_window_config: ChunkWindowConfig) -> ChunkWindowConfig:
+def chunk_window_config_with_family(
+    chunk_window_config: ChunkWindowConfig,
+) -> ChunkWindowConfig:
     """
     Return a ChunkWindowConfig with chunk_family_fields set to ['heading'].
 
@@ -93,7 +95,9 @@ def solr_index(chunk_window_config: ChunkWindowConfig) -> SolrIndex:
 
 
 @pytest.fixture
-def solr_index_with_family(chunk_window_config_with_family: ChunkWindowConfig) -> SolrIndex:
+def solr_index_with_family(
+    chunk_window_config_with_family: ChunkWindowConfig,
+) -> SolrIndex:
     """
     Return a SolrIndex with chunk_family_fields=['heading'].
 
@@ -165,8 +169,8 @@ class TestGetChunkBoundaryAndBudget:
         """Test that a chunk with a family field value gets its boundary dict and family budget."""
         chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 2, "heading": "Intro"})
         schema = solr_index_with_family.chunk_window_config
-        boundary, budget, is_orphan = solr_index_with_family._get_chunk_boundary_and_budget(
-            chunk, schema
+        boundary, budget, is_orphan = (
+            solr_index_with_family._get_chunk_boundary_and_budget(chunk, schema)
         )
         assert boundary == {"heading": "Intro"}
         assert budget == 3072
@@ -178,8 +182,8 @@ class TestGetChunkBoundaryAndBudget:
         """Test that a chunk missing all family field values is flagged as orphan and gets orphan budget."""
         chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 5})
         schema = solr_index_with_family.chunk_window_config
-        boundary, budget, is_orphan = solr_index_with_family._get_chunk_boundary_and_budget(
-            chunk, schema
+        boundary, budget, is_orphan = (
+            solr_index_with_family._get_chunk_boundary_and_budget(chunk, schema)
         )
         assert boundary == {}
         assert budget == 1536
@@ -191,7 +195,9 @@ class TestGetChunkBoundaryAndBudget:
         """Test that a chunk with at least one family field value is not treated as an orphan."""
         chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 2, "heading": "Ch1"})
         schema = solr_index_with_family.chunk_window_config
-        _, _, is_orphan = solr_index_with_family._get_chunk_boundary_and_budget(chunk, schema)
+        _, _, is_orphan = solr_index_with_family._get_chunk_boundary_and_budget(
+            chunk, schema
+        )
         assert is_orphan is False
 
 
@@ -201,7 +207,10 @@ class TestAssembleExpandedChunk:
     def test_content_joined_with_double_newline(self, solr_index: SolrIndex) -> None:
         """Test that selected chunk content is concatenated with double newlines."""
         chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 1})
-        selected = [{"chunk": "First.", "num_tokens": 5}, {"chunk": "Second.", "num_tokens": 5}]
+        selected = [
+            {"chunk": "First.", "num_tokens": 5},
+            {"chunk": "Second.", "num_tokens": 5},
+        ]
         result = solr_index._assemble_expanded_chunk(
             chunk, selected, {}, solr_index.chunk_window_config, matched_chunk_index=1
         )
@@ -210,7 +219,10 @@ class TestAssembleExpandedChunk:
     def test_empty_content_chunks_are_skipped(self, solr_index: SolrIndex) -> None:
         """Test that chunks with an empty content field are excluded from the joined output."""
         chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 0})
-        selected = [{"chunk": "", "num_tokens": 0}, {"chunk": "Only this.", "num_tokens": 5}]
+        selected = [
+            {"chunk": "", "num_tokens": 0},
+            {"chunk": "Only this.", "num_tokens": 5},
+        ]
         result = solr_index._assemble_expanded_chunk(
             chunk, selected, {}, solr_index.chunk_window_config, matched_chunk_index=0
         )
@@ -231,9 +243,11 @@ class TestAssembleExpandedChunk:
         """Test that doc_id from the parent document is included when the field is configured."""
         chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 0})
         result = solr_index._assemble_expanded_chunk(
-            chunk, [{"chunk": "x", "num_tokens": 5}],
+            chunk,
+            [{"chunk": "x", "num_tokens": 5}],
             {"doc_id": "content-abc", "title": "My Doc"},
-            solr_index.chunk_window_config, matched_chunk_index=0,
+            solr_index.chunk_window_config,
+            matched_chunk_index=0,
         )
         assert result.metadata["doc_id"] == "content-abc"
 
@@ -241,9 +255,11 @@ class TestAssembleExpandedChunk:
         """Test that title from the parent document is included when the field is configured."""
         chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 0})
         result = solr_index._assemble_expanded_chunk(
-            chunk, [{"chunk": "x", "num_tokens": 5}],
+            chunk,
+            [{"chunk": "x", "num_tokens": 5}],
             {"doc_id": "content-abc", "title": "My Doc"},
-            solr_index.chunk_window_config, matched_chunk_index=0,
+            solr_index.chunk_window_config,
+            matched_chunk_index=0,
         )
         assert result.metadata["title"] == "My Doc"
 
@@ -251,8 +267,11 @@ class TestAssembleExpandedChunk:
         """Test that source is always set to OKP_SOURCE regardless of parent doc content."""
         chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 0})
         result = solr_index._assemble_expanded_chunk(
-            chunk, [{"chunk": "x", "num_tokens": 5}], {},
-            solr_index.chunk_window_config, matched_chunk_index=0,
+            chunk,
+            [{"chunk": "x", "num_tokens": 5}],
+            {},
+            solr_index.chunk_window_config,
+            matched_chunk_index=0,
         )
         assert result.metadata["source"] == OKP_SOURCE
 
@@ -260,8 +279,11 @@ class TestAssembleExpandedChunk:
         """Test that chunk_id on the result matches the original chunk's chunk_id."""
         chunk = _make_chunk({"parent_id": "doc1", "chunk_index": 0})
         result = solr_index._assemble_expanded_chunk(
-            chunk, [{"chunk": "x", "num_tokens": 5}], {},
-            solr_index.chunk_window_config, matched_chunk_index=0,
+            chunk,
+            [{"chunk": "x", "num_tokens": 5}],
+            {},
+            solr_index.chunk_window_config,
+            matched_chunk_index=0,
         )
         assert result.chunk_id == "doc_chunk_0"
 
@@ -274,7 +296,9 @@ class TestSelectContextChunksInWindow:
         self, solr_index: SolrIndex, mocker: MockerFixture
     ) -> None:
         """Test that total_chunks < min_chunk_window triggers a full fetch of all chunks."""
-        all_chunks = [{"chunk_index": i, "chunk": f"c{i}", "num_tokens": 10} for i in range(3)]
+        all_chunks = [
+            {"chunk_index": i, "chunk": f"c{i}", "num_tokens": 10} for i in range(3)
+        ]
         mocker.patch.object(
             solr_index, "_fetch_context_chunks", AsyncMock(return_value=all_chunks)
         )
@@ -296,7 +320,9 @@ class TestSelectContextChunksInWindow:
         self, solr_index: SolrIndex, mocker: MockerFixture
     ) -> None:
         """Test that context chunks fitting within the token budget are returned without expansion."""
-        window = [{"chunk_index": i, "chunk": f"c{i}", "num_tokens": 50} for i in range(5)]
+        window = [
+            {"chunk_index": i, "chunk": f"c{i}", "num_tokens": 50} for i in range(5)
+        ]
         mocker.patch.object(
             solr_index, "_fetch_context_chunks", AsyncMock(return_value=window)
         )
@@ -318,11 +344,15 @@ class TestSelectContextChunksInWindow:
         self, solr_index: SolrIndex, mocker: MockerFixture
     ) -> None:
         """Test that an over-budget window calls _expand_chunk_window and returns its result."""
-        big_window = [{"chunk_index": i, "chunk": f"c{i}", "num_tokens": 1000} for i in range(5)]
+        big_window = [
+            {"chunk_index": i, "chunk": f"c{i}", "num_tokens": 1000} for i in range(5)
+        ]
         mocker.patch.object(
             solr_index, "_fetch_context_chunks", AsyncMock(return_value=big_window)
         )
-        mocker.patch.object(solr_index, "_expand_chunk_window", return_value=big_window[:2])
+        mocker.patch.object(
+            solr_index, "_expand_chunk_window", return_value=big_window[:2]
+        )
         result = await solr_index._select_context_chunks_in_window(
             client=mocker.MagicMock(),
             parent_id="doc1",


### PR DESCRIPTION
## Description

Decomposed three high-complexity methods into focused, single-responsibility helpers:

 - `_filter_tools_for_response` → extracted `_extract_user_prompt`, `_parse_llm_tool_names`, and `_build_filtered_tool_list`
- `_doc_to_chunk` → extracted `_build_doc_metadata` and `_add_window_config_metadata`
- `_apply_chunk_window_expansion` → extracted `_get_chunk_boundary_and_budget`, `_assemble_expanded_chunk`, and `_select_context_chunks_in_window`

   No changes to pre-existing logic or behaviour — purely structural. Unit tests added for
   each extracted helper.

   > **Note:** During review, CodeRabbit flagged two pre-existing issues in the extracted
   methods (`_parse_llm_tool_names` bracket matching and `_extract_user_prompt` content
   extraction for Pydantic `OpenAIResponseInput` objects). Both are valid findings but out of
   scope for this ticket, which was scoped to complexity reduction only. A follow-up ticket
   should be filed to address those correctness gaps.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude, CodeRabbit
- Generated by: Claude Sonnet 4.6

## Related Tickets & Documents

- Related Issue # LCORE-1547

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
Unit tests added for all extracted helpers and verified locally:
```
   uv run pytest tests/unit/providers/inline/agents/lightspeed_inline_agent/test_agent_instan
   ce_inline_agent.py tests/unit/providers/remote/solr_vector_io/ -v
   # 72 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized tool-filtering in the Lightspeed inline agent for clearer prompt parsing and tool selection flow.
  * Reworked Solr vector chunk-window expansion and document-to-chunk metadata assembly for more robust context selection and embedding handling.

* **Tests**
  * Added unit tests covering Lightspeed agent helper behaviors for prompt extraction and tool-name parsing.
  * Added extensive tests for Solr chunk-window expansion, boundary/budget logic, and expanded-chunk assembly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->