### PR TITLE
LCORE-1551: Don't check deprecated tests on CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,13 @@ test-solr = [
 
 [tool.pylint.main]
 source-roots = "."
+ignore = ["tests.py", "conftest.py"]
 
 [tool.ruff]
+extend-exclude = ["lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/tests.py"]
 
 [tool.ruff.lint]
-extend-select = ["UP006", "UP007", "UP010", "UP017", "UP035", "RUF100", "B009", "B010", "DTZ005", "I001", "RET504", "RET505"]
+extend-select = ["UP006", "UP007", "UP010", "UP017", "UP035", "RUF100", "B009", "B010", "DTZ005", "I001", "RET504", "RET505", "ANN201"]
 
 [tool.ruff.lint.flake8-tidy-imports]
 banned-api = { "unittest" = { msg = "use pytest instead of unittest" }, "unittest.mock" = { msg = "use pytest-mock instead of unittest.mock" } }
@@ -72,6 +74,7 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 ignore_missing_imports = true
 disable_error_code = "attr-defined"
+exclude = ["tests.py"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Description

LCORE-1551: Don't check deprecated tests on CI

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-1551
