### PR TITLE
RHIDP-16060: migrate Solr vector_io provider from llama-stack to ogx

### DIFF
--- a/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/README.md
+++ b/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/README.md
@@ -1,6 +1,6 @@
 # Solr Vector IO Provider
 
-A read-only vector_io provider implementation for llama-stack that integrates with Apache Solr's DenseVectorField and KNN search capabilities.
+A read-only vector_io provider implementation for ogx (formerly Llama Stack) that integrates with Apache Solr's DenseVectorField and KNN search capabilities.
 
 ## Features
 
@@ -43,7 +43,7 @@ The provider requires the following configuration:
 
 ## Usage
 
-This provider is designed to be used with llama-stack. The Solr collection should already exist and contain documents with:
+This provider is designed to be used with ogx. The Solr collection should already exist and contain documents with:
 
 1. A DenseVectorField for vector embeddings
 2. A content/text field for the chunk text
@@ -217,7 +217,7 @@ The provider supports dynamic filtering of search results by metadata fields usi
 **Simple equality filter:**
 
 ```python
-from llama_stack_api import ComparisonFilter
+from ogx_api import ComparisonFilter
 
 response = await adapter.query_chunks(
     vector_store_id="my-store",
@@ -255,7 +255,7 @@ response = await adapter.query_chunks(
 **Compound filters (AND/OR):**
 
 ```python
-from llama_stack_api import CompoundFilter, ComparisonFilter
+from ogx_api import CompoundFilter, ComparisonFilter
 
 response = await adapter.query_chunks(
     vector_store_id="my-store",

--- a/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/pyproject.toml
+++ b/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "solr-vector-io"
 version = "0.1.0"
-description = "Read-only Solr vector_io provider for llama-stack"
+description = "Read-only Solr vector_io provider for ogx (Llama Stack)"
 requires-python = ">=3.12"
 
 [tool.pytest.ini_options]

--- a/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/__init__.py
+++ b/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from llama_stack_api.datatypes import Api
+from ogx_api.datatypes import Api
 
 from .config import ChunkWindowConfig, SolrVectorIOConfig
 from .solr import SolrVectorIOAdapter

--- a/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/config.py
+++ b/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/config.py
@@ -2,8 +2,8 @@
 
 from typing import Any, Optional
 
-from llama_stack.core.storage.datatypes import KVStoreReference
-from llama_stack_api.schema_utils import json_schema_type
+from ogx.core.storage.datatypes import KVStoreReference
+from ogx_api.schema_utils import json_schema_type
 from pydantic import BaseModel, Field
 
 

--- a/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/filter_helpers.py
+++ b/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/filter_helpers.py
@@ -3,7 +3,7 @@
 import re
 from typing import Any, Optional
 
-from llama_stack.providers.utils.vector_io.filters import (
+from ogx.providers.utils.vector_io.filters import (
     ComparisonFilter,
     CompoundFilter,
     Filter,
@@ -158,7 +158,7 @@ def _convert_compound_filter(filter_obj: CompoundFilter) -> str:
 
 def filter_to_solr_fq(filter_obj: Filter) -> str:
     """
-    Convert llama-stack Filter to Solr filter query (fq) syntax.
+    Convert ogx Filter to Solr filter query (fq) syntax.
 
     Translates ComparisonFilter and CompoundFilter objects to Solr's
     native filter query language for metadata-based filtering.

--- a/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/solr.py
+++ b/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/src/solr_vector_io/solr.py
@@ -5,30 +5,30 @@
 from typing import Any, Optional
 
 import httpx
-from llama_stack.core.storage.kvstore import kvstore_impl
-from llama_stack.log import get_logger
-from llama_stack.providers.utils.memory.openai_vector_store_mixin import (
+from numpy.typing import NDArray
+from ogx.core.storage.kvstore import kvstore_impl
+from ogx.log import get_logger
+from ogx.providers.utils.memory.openai_vector_store_mixin import (
     OpenAIVectorStoreMixin,
 )
-from llama_stack.providers.utils.memory.vector_store import (
+from ogx.providers.utils.memory.vector_store import (
     ChunkForDeletion,
     EmbeddingIndex,
     VectorStoreWithIndex,
 )
-from llama_stack.providers.utils.vector_io.filters import ComparisonFilter, Filter
-from llama_stack_api.common.errors import VectorStoreNotFoundError
-from llama_stack_api.datatypes import VectorStoresProtocolPrivate
-from llama_stack_api.files import Files
-from llama_stack_api.inference import Inference
-from llama_stack_api.vector_io import (
+from ogx.providers.utils.vector_io.filters import ComparisonFilter, Filter
+from ogx_api.common.errors import VectorStoreNotFoundError
+from ogx_api.datatypes import VectorStoresProtocolPrivate
+from ogx_api.files import Files
+from ogx_api.inference import Inference
+from ogx_api.vector_io import (
     Chunk,
     EmbeddedChunk,
     QueryChunksRequest,
     QueryChunksResponse,
     VectorIO,
 )
-from llama_stack_api.vector_stores import VectorStore
-from numpy.typing import NDArray
+from ogx_api.vector_stores import VectorStore
 
 from .config import ChunkWindowConfig, SolrVectorIOConfig
 from .filter_helpers import build_solr_filter_query

--- a/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/tests.py
+++ b/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/tests.py
@@ -20,9 +20,9 @@ Skip slow tests (real embeddings):
 
 import numpy as np
 import pytest
-from llama_stack.core.storage.kvstore.config import SqliteKVStoreConfig
-from llama_stack_api.vector_io import Chunk
-from llama_stack_api.vector_stores import VectorStore as VectorDB
+from ogx.core.storage.kvstore.config import SqliteKVStoreConfig
+from ogx_api.vector_io import Chunk
+from ogx_api.vector_stores import VectorStore as VectorDB
 from src.solr_vector_io import (
     ChunkWindowConfig,
     SolrVectorIOAdapter,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
     "llama-stack==0.6.0",
     "llama-stack-api==0.6.0",
     "llama-stack-client==0.6.0",
+    "ogx==1.0.2",
+    "ogx-api==1.0.2",
     "httpx",
     "pydantic>=2.10.6",
     "litellm>=1.75.5.post1",

--- a/tests/unit/providers/remote/solr_vector_io/test_doc_to_chunk.py
+++ b/tests/unit/providers/remote/solr_vector_io/test_doc_to_chunk.py
@@ -8,7 +8,7 @@ instance.
 from typing import Any
 
 import pytest
-from llama_stack_api.vector_stores import VectorStore as VectorDB
+from ogx_api.vector_stores import VectorStore as VectorDB
 
 # pylint: disable=line-too-long
 from lightspeed_stack_providers.providers.remote.solr_vector_io.solr_vector_io.src.solr_vector_io.config import (

--- a/tests/unit/providers/remote/solr_vector_io/test_filters.py
+++ b/tests/unit/providers/remote/solr_vector_io/test_filters.py
@@ -6,7 +6,7 @@ and CompoundFilter types.
 """
 
 import pytest
-from llama_stack_api import ComparisonFilter, CompoundFilter
+from ogx_api import ComparisonFilter, CompoundFilter
 
 # pylint: disable=line-too-long
 from lightspeed_stack_providers.providers.remote.solr_vector_io.solr_vector_io.src.solr_vector_io.filter_helpers import (

--- a/tests/unit/providers/remote/solr_vector_io/test_solr_chunk_window.py
+++ b/tests/unit/providers/remote/solr_vector_io/test_solr_chunk_window.py
@@ -9,8 +9,8 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
-from llama_stack_api.vector_io import EmbeddedChunk
-from llama_stack_api.vector_stores import VectorStore as VectorDB
+from ogx_api.vector_io import EmbeddedChunk
+from ogx_api.vector_stores import VectorStore as VectorDB
 from pytest_mock import MockerFixture
 
 # pylint: disable=line-too-long


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
The llama-stack package was renamed to ogx in version 1.0.x. This updates all Python imports (llama_stack -> ogx, llama_stack_api -> ogx_api), bumps pyproject.toml dependencies from llama-stack==0.6.0 to ogx==1.0.2, and updates documentation references across README, AGENTS.md, CONTRIBUTING.md, and provider READMEs.

Docker/CI service names (docker-compose, e2e workflow) and Gherkin step strings are intentionally left unchanged to avoid breaking the test pipeline — those can be updated in a follow-up.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.6

## Related Tickets & Documents

- Task: [RHIDP-16060](https://redhat.atlassian.net/browse/RHIDP-16060)
   - EPIC: [RHIDP-14130](https://redhat.atlassian.net/browse/RHIDP-14130)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
